### PR TITLE
fix: hide status & navigation bars in fullscreen (#47)

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -232,20 +232,23 @@ fun createCustomWebview(
 
                     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                         activity.window.insetsController?.let { controller ->
-                            controller.hide(android.view.WindowInsets.Type.statusBars() or android.view.WindowInsets.Type.navigationBars())
+                            controller.hide(
+                                android.view.WindowInsets.Type.statusBars()
+                                    or android.view.WindowInsets.Type.navigationBars()
+                            )
                             controller.systemBarsBehavior =
                                 android.view.WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                         }
                     } else {
                         @Suppress("DEPRECATION")
                         activity.window.decorView.systemUiVisibility = (
-                                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                        or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                        or View.SYSTEM_UI_FLAG_FULLSCREEN
-                                        or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                                )
+                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                                or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                            )
                     }
 
                     visibility = View.GONE
@@ -261,7 +264,6 @@ fun createCustomWebview(
                     visibility = View.VISIBLE
                     customViewCallback?.onCustomViewHidden()
 
-                    // Restore system bars
                     activity?.let {
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                             it.window.insetsController?.show(android.view.WindowInsets.Type.statusBars() or android.view.WindowInsets.Type.navigationBars())


### PR DESCRIPTION
Resolves #47 - hide system bars while in full screen.