### PR TITLE
fix: focus of search suggestion no longer hijacking keyboard

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/AddressBarSearchSuggestions.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/AddressBarSearchSuggestions.kt
@@ -1,8 +1,10 @@
 package uk.nktnet.webviewkiosk.ui.components.webview
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -20,6 +22,9 @@ fun AddressBarSearchSuggestions(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+            )
     ) {
         suggestions.forEach { suggestion ->
             Box(
@@ -35,5 +40,6 @@ fun AddressBarSearchSuggestions(
                 )
             }
         }
+        Spacer(modifier = Modifier.padding(vertical = 8.dp))
     }
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -1,6 +1,5 @@
 package uk.nktnet.webviewkiosk.ui.screens
 
-import android.os.Build
 import android.webkit.CookieManager
 import android.webkit.HttpAuthHandler
 import android.webkit.URLUtil.isValidUrl
@@ -233,9 +232,6 @@ fun WebviewScreen(navController: NavController) {
                 return
             }
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            focusManager.clearFocus()
-        }
         webView.loadUrl(newUrl)
     }
 
@@ -244,9 +240,7 @@ fun WebviewScreen(navController: NavController) {
             userSettings.searchProviderUrl, input.trim()
         )
         if (searchUrl.isNotBlank() && (searchUrl != systemSettings.currentUrl || userSettings.allowRefresh)) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                webView.requestFocus()
-            }
+            webView.requestFocus()
             customLoadUrl(searchUrl)
         }
     }
@@ -342,26 +336,28 @@ fun WebviewScreen(navController: NavController) {
                             .align(Alignment.TopCenter)
                     )
                 }
-            }
-            if (
-                addressBarHasFocus
-                && suggestions.isNotEmpty()
-                && userSettings.searchSuggestionEngine != SearchSuggestionEngineOption.NONE
-            ) {
-                AddressBarSearchSuggestions(
-                    suggestions = suggestions,
-                    onSelect = { selected ->
-                        addressBarSearch(selected)
-                    },
-                    modifier = Modifier.fillMaxSize()
-                )
+
+                if (
+                    addressBarHasFocus
+                    && suggestions.isNotEmpty()
+                    && userSettings.searchSuggestionEngine != SearchSuggestionEngineOption.NONE
+                ) {
+                    AddressBarSearchSuggestions(
+                        suggestions = suggestions,
+                        onSelect = { selected ->
+                            addressBarSearch(selected)
+                        },
+                        modifier = Modifier.align(Alignment.TopStart)
+                    )
+                }
             }
         }
 
         if (!isLocked) {
             Box(modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Transparent)) {
+                .background(Color.Transparent)
+            ) {
                 FloatingMenuButton(
                     onHomeClick = {
                         focusManager.clearFocus()


### PR DESCRIPTION
Hitting enter now correctly unfocus the address bar when there is search suggestions opened.