### PR TITLE
fix: autofill services (e.g. bitwarden/protonpass) not working with address bar visible

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -2,6 +2,7 @@
   <dictionary name="project">
     <words>
       <w>autosizing</w>
+      <w>bitwarden</w>
       <w>densitydpi</w>
       <w>deps</w>
       <w>ecosia</w>

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
@@ -272,13 +273,26 @@ fun WebviewScreen(navController: NavController) {
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             if (showAddressBar) {
-                AddressBar(
-                    urlBarText = urlBarText,
-                    onUrlBarTextChange = { urlBarText = it },
-                    hasFocus = addressBarHasFocus,
-                    onFocusChanged = { focusState -> addressBarHasFocus = focusState.isFocused },
-                    addressBarSearch = addressBarSearch,
-                    customLoadUrl = ::customLoadUrl,
+                /**
+                 * Wrap in AndroidView to avoid breaking autofill (e.g. Bitwarden/Proton Pass)
+                 * in the WebView further below. Unsure why this is necessary.
+                 */
+                AndroidView(
+                    factory = { ctx ->
+                        ComposeView(ctx).apply {
+                            setContent {
+                                AddressBar(
+                                    urlBarText = urlBarText,
+                                    onUrlBarTextChange = { urlBarText = it },
+                                    hasFocus = addressBarHasFocus,
+                                    onFocusChanged = { focusState -> addressBarHasFocus = focusState.isFocused },
+                                    addressBarSearch = addressBarSearch,
+                                    customLoadUrl = ::customLoadUrl,
+                                )
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
 


### PR DESCRIPTION
For unclear reasons, when an OutlineTextField is visible together with the Android WebView, autofill from Bitwarden, Proton Pass, Samsung Pass, etc does not work.

A workaround that seems to work is wrapping the Address Bar with `AndroidView` follows:

```kotlin
AndroidView(
    factory = { ctx ->
        ComposeView(ctx).apply {
            setContent {
                AddressBar(
                    ...
                )
            }
        }
    },
)
```

Not pretty.