### PR TITLE
fix: infinite loop when blocking data: URLs

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -211,8 +211,14 @@ fun WebviewScreen(navController: NavController) {
             )
             return
         }
-        if (schemeType == SchemeType.FILE) {
-            val uri = newUrl.toUri()
+        val uri = newUrl.toUri()
+
+        if (schemeType === SchemeType.WEBVIEW_KIOSK && uri.host == "block") {
+            val blockUrl = uri.getQueryParameter("url")
+            if (blockUrl != null) {
+                webView.loadUrl(blockUrl)
+            }
+        } else if (schemeType == SchemeType.FILE) {
             val mimeType = getMimeType(context, uri)
             val file = File(uri.path ?: "")
             val pageContent = when {
@@ -230,10 +236,10 @@ fun WebviewScreen(navController: NavController) {
                     "UTF-8",
                     null
                 )
-                return
             }
+        } else {
+            webView.loadUrl(newUrl)
         }
-        webView.loadUrl(newUrl)
     }
 
     val addressBarSearch: (String) -> Unit = { input ->

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateBlockedPageHtml.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateBlockedPageHtml.kt
@@ -9,6 +9,7 @@ enum class BlockCause(val label: String) {
 
     override fun toString() = label
 }
+
 fun generateBlockedPageHtml(
     theme: ThemeOption,
     blockCause: BlockCause = BlockCause.BLACKLIST,


### PR DESCRIPTION
e.g. URL

```
data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAiIGhlaWdodD0iMTAwIj48Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI0MCIgZmlsbD0ic2t5Ymx1ZSIgc3Ryb2tlPSJkZWVwc2t5Ymx1ZSIgc3Ryb2tlLXdpZHRoPSI0Ii8+PC9zdmc+
```

with blacklist regex

```
^data:
```

---

## Update

A small issue with valid files not loading, and `==` instead of `===`, was fixed in the next commit:
- https://github.com/nktnet1/webview-kiosk/commit/88f2792e8574a610735e7841f0698e142602dfc0