### PR TITLE
feat: added back and home button for block page

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/blockPageUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/blockPageUtils.kt
@@ -72,7 +72,7 @@ fun loadBlockedPage(
         generateBlockedPageHtml(
             userSettings.theme,
             blockCause,
-            userSettings.blockedMessage,
+            userSettings,
             url
         ),
         "text/html",

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateBlockedPageHtml.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateBlockedPageHtml.kt
@@ -1,6 +1,7 @@
 package uk.nktnet.webviewkiosk.utils.webview.html
 
 import android.text.Html
+import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.config.option.ThemeOption
 
 enum class BlockCause(val label: String) {
@@ -13,7 +14,7 @@ enum class BlockCause(val label: String) {
 fun generateBlockedPageHtml(
     theme: ThemeOption,
     blockCause: BlockCause = BlockCause.BLACKLIST,
-    message: String,
+    userSettings: UserSettings,
     url: String,
 ): String {
     val themeCss = generateThemeCss(theme)
@@ -44,18 +45,32 @@ fun generateBlockedPageHtml(
                     border: none;
                     margin: 20px 0 30px 0px;
                 }
+                .actions {
+                    display: flex;
+                    gap: 12px;
+                    justify-content: center;
+                }
+                button {
+                    font-size: 16px;
+                    border-radius: 6px;
+                }
                 $themeCss
             </style>
           </head>
           <body>
             <h2>🚫 Access Blocked</h2>
-            <p>${Html.escapeHtml(message)}</p>
-            <hr />
+            <p>${Html.escapeHtml(userSettings.blockedMessage)}</p>
 
+            <div class="actions" style="margin-top:5;margin-bot:5px;">
+              <button style="width:100px;" onclick="history.back()">Back</button>
+              <button style="width:100px;" onclick="location.href='${userSettings.homeUrl}'">Home</button>
+            </div>
+
+            <hr />
             <b>URL</b>
             <p>${Html.escapeHtml(url)}</p>
-            <hr />
 
+            <hr />
             <b>CAUSE</b>
             <p>${blockCause}</p>
           </body>

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateThemeCss.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generateThemeCss.kt
@@ -2,55 +2,57 @@ package uk.nktnet.webviewkiosk.utils.webview.html
 
 import uk.nktnet.webviewkiosk.config.option.ThemeOption
 
-fun generateThemeCss(theme: ThemeOption): String {
-    return when (theme) {
-        ThemeOption.DARK -> """
-            body {
-                background-color: #121212;
-                color: #ffffff;
-            }
-            a {
-                color: #64b5f6;
-            }
-            hr {
-                border-top: 1px solid #aaaaaa;
-            }
-        """
-        ThemeOption.LIGHT -> """
-            body {
-                background-color: #ffffff;
-                color: #000000;
-            }
-            a {
-                color: #1a73e8;
-            }
-            hr {
-                border-top: 1px solid #555555;
-            }
-        """
-        ThemeOption.SYSTEM -> """
-            body {
-                background-color: #ffffff;
-                color: #000000;
-            }
-            a {
-                color: #1a73e8;
-            }
-            hr {
-                border-top: 1px solid #555555;
-            }
-            @media (prefers-color-scheme: dark) {
-                body {
-                    background-color: #121212;
-                    color: #ffffff;
-                }
-                a {
-                    color: #64b5f6;
-                }
-                hr {
-                    border-top: 1px solid #aaaaaa;
-                }
-            }
-        """
+private const val DARK_CSS = """
+    body {
+        background-color: #121212;
+        color: #ffffff;
     }
+    a {
+        color: #64b5f6;
+    }
+    hr {
+        border-top: 1px solid #aaaaaa;
+    }
+    button {
+        background-color: #1e1e1e;
+        color: #ffffff;
+        border: 1px solid #888888;
+        padding: 12px;
+    }
+    button:active {
+        background-color: #2a2a2a;
+    }
+"""
+
+private const val LIGHT_CSS = """
+    body {
+        background-color: #ffffff;
+        color: #000000;
+    }
+    a {
+        color: #1a73e8;
+    }
+    hr {
+        border-top: 1px solid #555555;
+    }
+    button {
+        background-color: #f1f3f4;
+        color: #000000;
+        border: 1px solid #888888;
+        padding: 12px;
+    }
+    button:active {
+        background-color: #e0e0e0;
+    }
+"""
+
+fun generateThemeCss(theme: ThemeOption): String = when (theme) {
+    ThemeOption.DARK -> DARK_CSS
+    ThemeOption.LIGHT -> LIGHT_CSS
+    ThemeOption.SYSTEM -> """
+        $LIGHT_CSS
+        @media (prefers-color-scheme: dark) {
+            $DARK_CSS
+        }
+    """
 }


### PR DESCRIPTION
Resolves #162.

CC @ByteAfterlife - see also #164 for how the full block page HTML can be customised.

---

<div>
  <img width="200" alt="block-page-back-and-home-buttons-dark" src="https://github.com/user-attachments/assets/e8419cc6-c2a4-405d-923b-9b5c66ee284c" />&nbsp;&nbsp;&nbsp;&nbsp;
  <img width="200" alt="block-page-back-and-home-buttons-light" src="https://github.com/user-attachments/assets/086a5dc7-d704-4e9c-ac46-5dd8c654b6e5" />
</div>