### PR TITLE
fix(mqtt): subscribe only on initial connect - avoid duplicated callbacks

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/MqttManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/MqttManager.kt
@@ -251,7 +251,6 @@ object MqttManager {
                     "connect success",
                     "Client ID: ${connectedContext.clientConfig.clientIdentifier.getOrNull()}"
                 )
-                subscribeToTopics()
                 publishEventMessage(
                     c,
                     MqttConnectedEvent(
@@ -365,6 +364,7 @@ object MqttManager {
             .send()
             .whenComplete { _, throwable ->
                 if (throwable == null) {
+                    subscribeToTopics()
                     onConnected?.invoke()
                 } else {
                     addDebugLog("connect failed", throwable.message)


### PR DESCRIPTION
Related issues:
- https://github.com/hivemq/hivemq-mqtt-client/issues/581
- https://github.com/hivemq/hivemq-mqtt-client/issues/552