### PR TITLE
fix: app storage side effect (getExternalFilesDir)

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -106,13 +106,7 @@ class MainActivity : AppCompatActivity() {
         userSettings = UserSettings(this)
         systemSettings = SystemSettings(this)
         DeviceOwnerManager.init(this)
-
-        /**
-         * This triggers a side effect, creating a directory such as:
-         *     /storage/emulated/0/Android/data/uk.nktnet.webviewkiosk/files
-         * which may also be aliased as:
-         *     /sdcard/Android/data/uk.nktnet.webviewkiosk/files
-         */
+        // https://github.com/nktnet1/webview-kiosk/pull/195
         getExternalFilesDir(null)
 
         if (DeviceOwnerManager.status.value.mode == DeviceOwnerMode.DeviceOwner) {


### PR DESCRIPTION
Calls [getExternalFilesDir(null)](https://developer.android.com/reference/android/content/ContextWrapper.html#getExternalFilesDir(java.lang.String)) in `MainActivity -> onCreate`.

---

This also triggers a side effect, creating a directory such as:
```
/storage/emulated/0/Android/data/uk.nktnet.webviewkiosk/files
```

Which allows for the mapping of the following:
```
/sdcard/Android/data/uk.nktnet.webviewkiosk/files
```

cc @kiddyfurby from https://github.com/nktnet1/webview-kiosk/discussions/192#discussioncomment-15396805

---

You can then perform actions such as:

```sh
# Create a test file
echo "Hello WebViewKiosk" > sample.txt

# NOTE: use com.nktnet.webview_kiosk if installed from the Google Play Store
adb shell mkdir -p /sdcard/Android/data/uk.nktnet.webviewkiosk/files/

# Copy to the app's external storage
adb push sample.txt /sdcard/Android/data/uk.nktnet.webviewkiosk/files/
```

and access the file at:

```
file:///sdcard/Android/data/uk.nktnet.webviewkiosk/files/sample.txt
```

---

Skipping the sdcard altogether and using the `/storage/emulated/0/Android/data/uk.nktnet.webviewkiosk/files` will probably also work, as long as you `mkdir` via `adb`.