### PR TITLE
fix: url validation crash when failing to decode file url

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/inputValidation.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/inputValidation.kt
@@ -5,9 +5,6 @@ import android.webkit.URLUtil.isValidUrl
 import androidx.core.net.toUri
 import java.io.File
 
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
-
 fun isDataSchemeUrl(url: String): Boolean {
     val dataUrlRegex = Regex(
         """^data:(?:[a-zA-Z0-9!#$&.+\-^_]+/[a-zA-Z0-9!#$&.+\-^_]+)?(?:;base64)?,.*"""
@@ -23,11 +20,9 @@ fun validateUrl(input: String): Boolean {
     val uri = trimmedInput.toUri()
     return when (uri.scheme) {
         "file" -> {
-            val filePath = URLDecoder.decode(
-                trimmedInput.removePrefix("file://"),
-                StandardCharsets.UTF_8.name()
-            )
-            File(filePath).exists()
+            uri.path?.let {
+                File(it).exists()
+            } ?: false
         }
         "http" -> {
             isValidUrl(trimmedInput)


### PR DESCRIPTION
Crash log from playstore (java.lang.IllegalArgumentException):

```
Exception java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern
  at java.net.URLDecoder.decode (URLDecoder.java:232)
  at java.net.URLDecoder.decode (URLDecoder.java:143)
  at uk.nktnet.webviewkiosk.utils.InputValidationKt.validateUrl (InputValidation.kt:26)
  at uk.nktnet.webviewkiosk.ui.components.setting.fielditems.webcontent.HomeUrlSettingKt.HomeUrlSetting$lambda$2$0 (HomeUrlSetting.kt:57)
  at uk.nktnet.webviewkiosk.ui.components.setting.fields.TextSettingFieldItemKt.TextSettingFieldItem$lambda$18$0$1$0 (TextSettingFieldItem.kt:145)
  at androidx.compose.foundation.text.BasicTextFieldKt.BasicTextField$lambda$46$lambda$45 (BasicTextField.kt:769)
  at androidx.compose.foundation.text.LegacyTextFieldState.onValueChange$lambda$2 (LegacyTextFieldState.java:889)
  at androidx.compose.foundation.text.TextFieldDelegate$Companion.onEditCommand$foundation_release (TextFieldDelegate.java:293)
  at androidx.compose.foundation.text.TextFieldDelegate$Companion.restartInput$lambda$4 (TextFieldDelegate.java:342)
  at androidx.compose.foundation.text.input.internal.LegacyTextInputMethodRequest$createInputConnection$1.onEditCommands (LegacyTextInputMethodRequest.java:274)
  at androidx.compose.foundation.text.input.internal.RecordingInputConnection.endBatchEditInternal (RecordingInputConnection.android.kt:191)
  at androidx.compose.foundation.text.input.internal.RecordingInputConnection.addEditCommandWithBatch (RecordingInputConnection.android.kt:163)
  at androidx.compose.foundation.text.input.internal.RecordingInputConnection.commitText (RecordingInputConnection.android.kt:214)
  at androidx.compose.ui.text.input.NullableInputConnectionWrapperApi21.commitText (NullableInputConnectionWrapper.android.kt:133)
  at android.view.inputmethod.RemoteInputConnectionImpl.lambda$commitText$17 (RemoteInputConnectionImpl.java:612)
  at android.view.inputmethod.RemoteInputConnectionImpl.$r8$lambda$jNtA8MXobPnaECkNr8D9WTYrxk0 (Unknown Source)
  at android.view.inputmethod.RemoteInputConnectionImpl$$ExternalSyntheticLambda47.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9593)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:593)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:936)
```