### PR TITLE
fix: resolve crash when clearing history on empty stack

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
@@ -106,7 +106,13 @@ object WebViewNavigation {
     }
 
     fun clearHistory(systemSettings: SystemSettings) {
-        val currentIndex = systemSettings.historyIndex.coerceIn(0, systemSettings.historyStack.lastIndex)
+        if (systemSettings.historyStack.isEmpty()) {
+            return
+        }
+        val currentIndex = systemSettings.historyIndex.coerceIn(
+            0,
+            systemSettings.historyStack.lastIndex
+        )
         val currentEntry = systemSettings.historyStack.getOrNull(currentIndex)
         if (currentEntry != null) {
             systemSettings.historyStack = listOf(currentEntry)


### PR DESCRIPTION
Playstore crash details:

```
Exception java.lang.IllegalArgumentException: Cannot coerce value to an empty range: maximum -1 is less than minimum 0.
  at kotlin.ranges.RangesKt___RangesKt.coerceIn (RangesKt___Ranges.kt:1449)
  at uk.nktnet.webviewkiosk.utils.webview.WebViewNavigation.clearHistory (WebViewNavigation.java:109)
  at uk.nktnet.webviewkiosk.ui.screens.SettingsMoreActionsScreenKt.SettingsMoreActionsScreen$lambda$6$0$6$1$0 (SettingsMoreActionsScreen.kt:263)
  at androidx.compose.foundation.ClickableNode.onPointerEvent-H0pRuoY (Clickable.kt:1009)
  at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass (HitPathTracker.kt:436)
  at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass (HitPathTracker.kt:422)
  at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass (HitPathTracker.kt:422)
  at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass (NodeParent.java:275)
  at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges (HitPathTracker.kt:171)
  at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog (PointerInputEventProcessor.java:118)
  at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc (AndroidComposeView.android.kt:2428)
  at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc (AndroidComposeView.android.kt:2378)
  at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent (AndroidComposeView.android.kt:2249)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3143)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2826)
  at com.android.internal.policy.DecorView.superDispatchTouchEvent (DecorView.java:503)
  at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent (PhoneWindow.java:2017)
  at android.app.Activity.dispatchTouchEvent (Activity.java:4666)
  at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.java:69)
  at com.android.internal.policy.DecorView.dispatchTouchEvent (DecorView.java:441)
  at android.view.View.dispatchPointerEvent (View.java:17196)
  at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent (ViewRootImpl.java:8585)
  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess (ViewRootImpl.java:8335)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7702)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:7759)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:7725)
  at android.view.ViewRootImpl$AsyncInputStage.forward (ViewRootImpl.java:7896)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:7733)
  at android.view.ViewRootImpl$AsyncInputStage.apply (ViewRootImpl.java:7953)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7706)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:7759)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:7725)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:7733)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7706)
  at android.view.ViewRootImpl.deliverInputEvent (ViewRootImpl.java:11033)
  at android.view.ViewRootImpl.doProcessInputEvents (ViewRootImpl.java:10973)
  at android.view.ViewRootImpl.enqueueInputEvent (ViewRootImpl.java:10941)
  at android.view.ViewRootImpl.processRawInputEvent (ViewRootImpl.java:11377)
  at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent (ViewRootImpl.java:11161)
  at android.view.InputEventReceiver.dispatchInputEvent (InputEventReceiver.java:284)
  at android.os.MessageQueue.nativePollOnce
  at android.os.MessageQueue.nextDeliQueue (MessageQueue.java:780)
  at android.os.MessageQueue.next (MessageQueue.java:760)
  at android.os.Looper.loopOnce (Looper.java:196)
  at android.os.Looper.loop (Looper.java:367)
  at android.app.ActivityThread.main (ActivityThread.java:9333)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:566)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:929)
```