### PR TITLE
fix: safely handle init mqtt foreground service

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/mqttUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/mqttUtils.kt
@@ -2,6 +2,7 @@ package uk.nktnet.webviewkiosk.utils
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -10,8 +11,10 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONObject
+import uk.nktnet.webviewkiosk.config.Constants
 import uk.nktnet.webviewkiosk.config.UserSettingsKeys
 import uk.nktnet.webviewkiosk.managers.MqttManager
+import uk.nktnet.webviewkiosk.managers.ToastManager
 import uk.nktnet.webviewkiosk.services.MqttForegroundService
 
 fun isValidMqttPublishTopic(topic: String): Boolean {
@@ -124,13 +127,20 @@ fun filterSettingsJson(
 }
 
 fun initMqttForegroundService(context: Context, start: Boolean) {
-    val intent = Intent(
-        context,
-        MqttForegroundService::class.java
-    )
-    if (start) {
-        context.startService(intent)
-    } else {
-        context.stopService(intent)
+    val intent = Intent(context, MqttForegroundService::class.java)
+    try {
+        if (start) {
+            context.startService(intent)
+        } else {
+            context.stopService(intent)
+        }
+    } catch (e: Exception) {
+        val errorMessage = "Failed to ${if (start) "start" else "stop"} MQTT foreground service"
+        Log.e(
+            Constants.APP_SCHEME,
+            errorMessage,
+            e
+        )
+        ToastManager.show(context, errorMessage)
     }
 }


### PR DESCRIPTION
Crashlog from playstore:

```
Exception java.lang.IllegalStateException:
  at android.app.ContextImpl.startServiceCommon (ContextImpl.java:1715)
  at android.app.ContextImpl.startService (ContextImpl.java:1670)
  at android.content.ContextWrapper.startService (ContextWrapper.java:720)
  at android.content.ContextWrapper.startService (ContextWrapper.java:720)
  at uk.nktnet.webviewkiosk.utils.MqttUtilsKt.initMqttForegroundService (mqttUtils.kt:132)
  at uk.nktnet.webviewkiosk.utils.DeviceUtilsKt.updateDeviceSettings (deviceUtils.kt:88)
  at uk.nktnet.webviewkiosk.MainActivity.onStart (MainActivity.kt:307)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1435)
  at android.app.Activity.performStart (Activity.java:8024)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:3528)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:221)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:201)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:173)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2116)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7720)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:612)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:997)
```
