### PR TITLE
fix: millisecond delays, await frame and default min size for elements that requests focus

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -66,6 +66,7 @@ import uk.nktnet.webviewkiosk.utils.setupLockTaskPackage
 import uk.nktnet.webviewkiosk.utils.tryLockTask
 import uk.nktnet.webviewkiosk.utils.tryUnlockTask
 import uk.nktnet.webviewkiosk.utils.updateDeviceSettings
+import kotlin.time.Duration.Companion.milliseconds
 
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavHostController
@@ -118,7 +119,7 @@ class MainActivity : AppCompatActivity() {
             && userSettings.dhizukuRequestPermissionOnLaunch
         ) {
             lifecycleScope.launch {
-                delay(1000)
+                delay(1000.milliseconds)
                 DeviceOwnerManager.requestDhizukuPermission(
                     onGranted = {
                         setupLockTaskPackage(this@MainActivity)
@@ -206,7 +207,7 @@ class MainActivity : AppCompatActivity() {
 
                     if (settings.message.reloadActivity) {
                         lifecycleScope.launch(Dispatchers.Main) {
-                            delay(100)
+                            delay(100.milliseconds)
                             if (settings.message.reloadActivity) {
                                 updateDeviceSettings(context)
                             }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/handlers/BackButtonHandler.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/handlers/BackButtonHandler.kt
@@ -15,6 +15,7 @@ import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.config.option.BackButtonHoldActionOption
 import uk.nktnet.webviewkiosk.states.BackButtonStateSingleton
 import uk.nktnet.webviewkiosk.utils.webview.WebViewNavigation
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun BackPressHandler(
@@ -43,7 +44,7 @@ fun BackPressHandler(
                     WebViewNavigation.goHome(customLoadUrl, systemSettings, userSettings)
                 }
                 scope.launch {
-                    delay(1000L)
+                    delay(1000.milliseconds)
                     enableBack = true
                 }
             }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/handlers/DimScreenOnInactivityTimeoutHandler.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/handlers/DimScreenOnInactivityTimeoutHandler.kt
@@ -12,6 +12,7 @@ import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.states.UserInteractionStateSingleton
 import uk.nktnet.webviewkiosk.utils.setWindowBrightness
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun DimScreenOnInactivityTimeoutHandler() {
@@ -28,7 +29,7 @@ fun DimScreenOnInactivityTimeoutHandler() {
     LaunchedEffect(lastInteraction) {
         setWindowBrightness(context, userSettings.brightness)
         while (true) {
-            delay(500L)
+            delay(500.milliseconds)
             val elapsed = try {
                 System.currentTimeMillis() - lastInteraction
             } catch (e: IllegalStateException) {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/handlers/ResetOnInactivityTimeoutHandler.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/handlers/ResetOnInactivityTimeoutHandler.kt
@@ -27,6 +27,7 @@ import uk.nktnet.webviewkiosk.config.SystemSettings
 import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.states.UserInteractionStateSingleton
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
 
 const val RESET_TIMEOUT_INT = -1
 
@@ -57,7 +58,7 @@ fun ResetOnInactivityTimeoutHandler(
     LaunchedEffect(lastInteraction) {
         countdown = RESET_TIMEOUT_INT
         while (true) {
-            delay(500L)
+            delay(500.milliseconds)
             val elapsed = try {
                 System.currentTimeMillis() - lastInteraction
             } catch (e: IllegalStateException) {
@@ -71,7 +72,7 @@ fun ResetOnInactivityTimeoutHandler(
             if (elapsed >= countdownStartDuration) {
                 countdown = Constants.INACTIVITY_COUNTDOWN_SECONDS
                 while (countdown > 0) {
-                    delay(1000L)
+                    delay(1000.milliseconds)
                     countdown--
                 }
                 handleTimeoutReached()

--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/BackButtonManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/BackButtonManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import uk.nktnet.webviewkiosk.states.BackButtonStateSingleton
+import kotlin.time.Duration.Companion.milliseconds
 
 class BackButtonManager(
     private val lifecycleScope: LifecycleCoroutineScope,
@@ -38,7 +39,7 @@ class BackButtonManager(
         override fun handleOnBackStarted(backEvent: BackEventCompat) {
             if (shouldUsePredictiveBackLongPress() && isButtonPress(backEvent)) {
                 backLongPressJob = lifecycleScope.launch {
-                    delay(ViewConfiguration.getLongPressTimeout().toLong())
+                    delay(ViewConfiguration.getLongPressTimeout().milliseconds)
                     BackButtonStateSingleton.emitLongPress()
                 }
             }
@@ -71,7 +72,7 @@ class BackButtonManager(
         ) {
             if (backLongPressJob == null) {
                 backLongPressJob = lifecycleScope.launch {
-                    delay(ViewConfiguration.getLongPressTimeout().toLong())
+                    delay(ViewConfiguration.getLongPressTimeout().milliseconds)
                     BackButtonStateSingleton.emitLongPress()
                     isLegacyLongPressEmitted = true
                 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/services/LockTaskService.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/services/LockTaskService.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import uk.nktnet.webviewkiosk.BuildConfig
 import uk.nktnet.webviewkiosk.managers.CustomNotificationManager
 import uk.nktnet.webviewkiosk.managers.CustomNotificationType
+import kotlin.time.Duration.Companion.milliseconds
 
 @RequiresApi(28)
 class LockTaskService: Service() {
@@ -70,9 +71,9 @@ class LockTaskService: Service() {
         if (updateJob?.isActive != true) {
             updateJob = scope.launch {
                 val am = getSystemService(ActivityManager::class.java)
-                delay(3000)
+                delay(3000.milliseconds)
                 while (am.lockTaskModeState == ActivityManager.LOCK_TASK_MODE_LOCKED) {
-                    delay(1000)
+                    delay(1000.milliseconds)
                 }
                 stopLockTaskService()
             }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/services/MqttForegroundService.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/services/MqttForegroundService.kt
@@ -26,6 +26,7 @@ import uk.nktnet.webviewkiosk.managers.CustomNotificationManager
 import uk.nktnet.webviewkiosk.managers.CustomNotificationType
 import uk.nktnet.webviewkiosk.managers.MqttManager
 import uk.nktnet.webviewkiosk.managers.RemoteMessageManager
+import kotlin.time.Duration.Companion.milliseconds
 
 class MqttForegroundService : Service() {
     private var isServiceActive = true
@@ -116,7 +117,7 @@ class MqttForegroundService : Service() {
                     }
                     lastStatus = status
                     updateNotification(status)
-                    delay(1000L)
+                    delay(1000.milliseconds)
                 }
             }
         }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/states/LockStateSingleton.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/states/LockStateSingleton.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import uk.nktnet.webviewkiosk.config.option.LockStateType
 import uk.nktnet.webviewkiosk.managers.MqttManager
 import uk.nktnet.webviewkiosk.utils.getIsLocked
+import kotlin.time.Duration.Companion.milliseconds
 
 object LockStateSingleton {
     private val _isLocked = mutableStateOf(false)
@@ -43,7 +44,7 @@ object LockStateSingleton {
                         MqttManager.publishUnlockEvent()
                     }
                 }
-                delay(1000L)
+                delay(1000.milliseconds)
             }
         }
     }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -142,6 +143,7 @@ fun CustomAuthPasswordDialog() {
                     ),
                     modifier = Modifier
                         .fillMaxWidth()
+                        .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
                         .focusRequester(focusRequester),
                     singleLine = true,
                     trailingIcon = {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
@@ -40,12 +40,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import uk.nktnet.webviewkiosk.R
 import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.managers.AuthenticationManager
 import uk.nktnet.webviewkiosk.managers.ToastManager
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun CustomAuthPasswordDialog() {
@@ -68,7 +70,8 @@ fun CustomAuthPasswordDialog() {
     var isError by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        delay(100)
+        delay(100.milliseconds)
+        awaitFrame()
         focusRequester.requestFocus()
     }
 
@@ -83,7 +86,7 @@ fun CustomAuthPasswordDialog() {
                 val elapsed = System.currentTimeMillis() - start
                 val remaining = 1000L - elapsed
                 if (remaining > 0) {
-                    delay(remaining)
+                    delay(remaining.milliseconds)
                 }
                 isError = true
                 ToastManager.show(context, "Incorrect password")

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/UnifiedPushControlButtons.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/UnifiedPushControlButtons.kt
@@ -51,6 +51,7 @@ import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.config.unifiedpush.UnifiedPushEndpoint
 import uk.nktnet.webviewkiosk.managers.UnifiedPushManager
 import uk.nktnet.webviewkiosk.utils.normaliseInfoText
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun UnifiedPushControlButtons() {
@@ -78,7 +79,7 @@ fun UnifiedPushControlButtons() {
 
     LaunchedEffect(Unit) {
         while (true) {
-            delay(1000)
+            delay(1000.milliseconds)
             savedDistributor = UnifiedPushManager.getSavedDistributor(context)
             ackDistributor = UnifiedPushManager.getAckDistributor(context)
             if (ackDistributor.isNullOrBlank()) {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.android.awaitFrame
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import uk.nktnet.webviewkiosk.R
 import uk.nktnet.webviewkiosk.config.UserSettings
@@ -39,6 +41,7 @@ import uk.nktnet.webviewkiosk.managers.ToastManager
 import uk.nktnet.webviewkiosk.ui.components.setting.fields.CustomSettingFieldItem
 import uk.nktnet.webviewkiosk.utils.keyEventToShortcutString
 import uk.nktnet.webviewkiosk.utils.modifierKeyCodes
+import kotlin.time.Duration.Companion.milliseconds
 
 fun handleUnlockShortcutKeyEvent(
     context: Context,
@@ -78,7 +81,11 @@ fun CustomUnlockShortcutSetting() {
     LaunchedEffect(isPressed) {
         if (isPressed && !isListening) {
             isListening = true
-            coroutineScope.launch { focusRequester.requestFocus() }
+            coroutineScope.launch {
+                delay(100.milliseconds)
+                awaitFrame()
+                focusRequester.requestFocus()
+            }
         }
     }
 
@@ -157,7 +164,11 @@ fun CustomUnlockShortcutSetting() {
                             isListening = false
                         } else {
                             isListening = true
-                            coroutineScope.launch { focusRequester.requestFocus() }
+                            coroutineScope.launch {
+                                delay(100.milliseconds)
+                                awaitFrame()
+                                focusRequester.requestFocus()
+                            }
                         }
                     },
                     colors = androidx.compose.material3.ButtonDefaults.buttonColors(

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -135,12 +137,15 @@ fun CustomUnlockShortcutSetting() {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
+                        .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
                         .focusRequester(focusRequester)
                         .focusable()
                         .background(
-                            if (isListening)
-                                androidx.compose.material3.MaterialTheme.colorScheme.surfaceVariant
-                            else Color.Transparent
+                            if (isListening) {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            } else {
+                                Color.Transparent
+                            }
                         )
                         .onPreviewKeyEvent { event ->
                             val (newDraft, newListening) =

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webbrowsing/SearchProviderUrlSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webbrowsing/SearchProviderUrlSetting.kt
@@ -113,7 +113,9 @@ fun SearchProviderUrlSetting() {
                                         MaterialTheme.colorScheme.onSurface
                                     }
                                 ),
-                                elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
+                                elevation = ButtonDefaults.buttonElevation(
+                                    defaultElevation = 0.dp
+                                )
                             ) {
                                 Text(
                                     text = name,

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/mqtt/MqttControlButtons.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/mqtt/MqttControlButtons.kt
@@ -29,6 +29,7 @@ import uk.nktnet.webviewkiosk.config.remote.outbound.OutboundDisconnectingEvent
 import uk.nktnet.webviewkiosk.managers.MqttManager
 import uk.nktnet.webviewkiosk.managers.ToastManager
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun MqttControlButtons() {
@@ -47,7 +48,7 @@ fun MqttControlButtons() {
     ) {
         while (true) {
             mqttClientState = MqttManager.getState()
-            delay(500)
+            delay(500.milliseconds)
         }
     }
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/AddressBar.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/AddressBar.kt
@@ -60,6 +60,7 @@ import uk.nktnet.webviewkiosk.utils.handleUserTouchEvent
 import uk.nktnet.webviewkiosk.utils.tryLockTask
 import uk.nktnet.webviewkiosk.utils.unlockWithAuthIfRequired
 import uk.nktnet.webviewkiosk.utils.webview.WebViewNavigation
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 private fun AddressBarMenuItem(
@@ -111,7 +112,7 @@ fun AddressBar(
     val isLocked by LockStateSingleton.isLocked
 
     LaunchedEffect(Unit) {
-        delay(200)
+        delay(200.milliseconds)
         allowFocus = true
     }
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/HistoryDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/HistoryDialog.kt
@@ -52,6 +52,7 @@ import uk.nktnet.webviewkiosk.utils.handleUserTouchEvent
 import uk.nktnet.webviewkiosk.utils.webview.WebViewNavigation
 import java.util.Date
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 
 private fun formatDatetime(context: Context, timestamp: Long): String {
     val now = System.currentTimeMillis()
@@ -110,7 +111,7 @@ fun HistoryDialog(
             when (commandMessage.message) {
                 is InboundClearHistoryCommand -> {
                     // The actual history is cleared in main activity
-                    delay(100)
+                    delay(100.milliseconds)
                     history = systemSettings.historyStack
                 }
                 else -> Unit

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/KioskControlPanel.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/KioskControlPanel.kt
@@ -69,6 +69,7 @@ import uk.nktnet.webviewkiosk.utils.tryLockTask
 import uk.nktnet.webviewkiosk.utils.unlockWithAuthIfRequired
 import uk.nktnet.webviewkiosk.utils.webview.WebViewNavigation
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 private fun ActionButton(
@@ -137,7 +138,7 @@ fun KioskControlPanel(
 
     LaunchedEffect(tapsLeft, lastTapTime) {
         if (tapsLeft in 1..5) {
-            delay(maxInterval)
+            delay(maxInterval.milliseconds)
             if (System.currentTimeMillis() - lastTapTime >= maxInterval) {
                 tapsLeft = requiredTaps
             }
@@ -148,7 +149,7 @@ fun KioskControlPanel(
         showDialog = true
         enableDismiss = false
         scope.launch {
-            delay(1000L)
+            delay(1000.milliseconds)
             enableDismiss = true
         }
     }
@@ -200,7 +201,7 @@ fun KioskControlPanel(
                                     enableInteraction = false
                                     handleShowDialog()
                                     scope.launch {
-                                        delay(600L)
+                                        delay(600.milliseconds)
                                         enableInteraction = true
                                     }
                                 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
@@ -35,7 +35,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.android.awaitFrame
+import kotlinx.coroutines.delay
 import uk.nktnet.webviewkiosk.R
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 private fun RoundIconButton(
@@ -86,6 +89,8 @@ fun WebViewFindBar(
 
     LaunchedEffect(Unit) {
         if (isActiveFindInPage) {
+            delay(100.milliseconds)
+            awaitFrame()
             focusRequester.requestFocus()
         }
     }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -116,6 +117,7 @@ fun WebViewFindBar(
                 fontSize = 14.sp
             ),
             modifier = Modifier
+                .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
                 .focusRequester(focusRequester)
                 .weight(1f),
             keyboardOptions = KeyboardOptions.Default.copy(

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/AdminRestrictionsChangedScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/AdminRestrictionsChangedScreen.kt
@@ -34,6 +34,7 @@ import androidx.navigation.NavController
 import kotlinx.coroutines.delay
 import uk.nktnet.webviewkiosk.R
 import uk.nktnet.webviewkiosk.utils.navigateToWebViewScreen
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun AdminRestrictionsChangedScreen(
@@ -45,7 +46,7 @@ fun AdminRestrictionsChangedScreen(
     LaunchedEffect(Unit) {
         while (remaining > 1) {
             remaining -= 1
-            delay(1000)
+            delay(1000.milliseconds)
         }
         navigateToWebViewScreen(navController)
     }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsDeviceOwnerScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsDeviceOwnerScreen.kt
@@ -58,6 +58,7 @@ import uk.nktnet.webviewkiosk.ui.components.setting.fielditems.device.owner.lock
 import uk.nktnet.webviewkiosk.utils.normaliseInfoText
 import uk.nktnet.webviewkiosk.utils.openPackage
 import uk.nktnet.webviewkiosk.utils.setupLockTaskPackage
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun SettingsDeviceOwnerScreen(navController: NavController) {
@@ -88,7 +89,7 @@ fun SettingsDeviceOwnerScreen(navController: NavController) {
 
     LaunchedEffect(Unit) {
         while (true) {
-            delay(1000)
+            delay(1000.milliseconds)
             isDeviceOwner = dpm.isDeviceOwnerApp(context.packageName)
             hasOwnerPermission = DeviceOwnerManager.hasOwnerPermission(context)
         }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -34,6 +34,7 @@ import androidx.core.net.toUri
 import androidx.navigation.NavController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -97,6 +98,7 @@ import uk.nktnet.webviewkiosk.utils.webview.isCustomBlockPageUrl
 import uk.nktnet.webviewkiosk.utils.webview.loadBlockedPage
 import uk.nktnet.webviewkiosk.utils.webview.resolveUrlOrSearch
 import java.io.File
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun WebviewScreen(navController: NavController) {
@@ -155,7 +157,11 @@ fun WebviewScreen(navController: NavController) {
         if (!isActiveFindInPage) {
             isActiveFindInPage = true
         } else {
-            findInPageFocusRequester.requestFocus()
+            scope.launch {
+                delay(100.milliseconds)
+                awaitFrame()
+                findInPageFocusRequester.requestFocus()
+            }
         }
     }
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -188,7 +188,7 @@ fun WebviewScreen(navController: NavController) {
                 && urlBarText.text.isNotBlank()
                 && !isValidUrl(urlBarText.text)
             ) {
-                delay(300)
+                delay(300.milliseconds)
                 suggestions = try {
                     withContext(Dispatchers.IO) {
                         SearchSuggestionEngine.suggest(
@@ -229,7 +229,7 @@ fun WebviewScreen(navController: NavController) {
         ) {
             mqttLastPublishedUrlJob?.cancel()
             mqttLastPublishedUrlJob = scope.launch {
-                delay(1000)
+                delay(1000.milliseconds)
                 MqttManager.publishUrlChangedEvent(url)
                 mqttLastPublishedUrl = url
             }
@@ -353,7 +353,9 @@ fun WebviewScreen(navController: NavController) {
     ) {
         LaunchedEffect(lastErrorUrl) {
             while (lastErrorUrl.isNotEmpty()) {
-                delay(userSettings.refreshOnLoadingErrorIntervalSeconds * 1000L)
+                delay(
+                    (userSettings.refreshOnLoadingErrorIntervalSeconds * 1000).milliseconds
+                )
                 WebViewNavigation.refresh(
                     ::customLoadUrl, systemSettings, userSettings
                 )

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.pointerInteropFilter
 import kotlinx.coroutines.android.awaitFrame
+import kotlinx.coroutines.delay
 import uk.nktnet.webviewkiosk.states.UserInteractionStateSingleton
+import kotlin.time.Duration.Companion.milliseconds
 
 fun Modifier.handleUserTouchEvent(): Modifier {
     return this.pointerInteropFilter { _ ->
@@ -30,6 +32,7 @@ fun Modifier.handleUserKeyEvent(
 
     LaunchedEffect(isVisible) {
         if (isVisible) {
+            delay(100.milliseconds)
             awaitFrame()
             focusRequester.requestFocus()
         }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
@@ -3,6 +3,7 @@ package uk.nktnet.webviewkiosk.utils
 
 import android.content.Context
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -11,6 +12,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.delay
 import uk.nktnet.webviewkiosk.states.UserInteractionStateSingleton
@@ -39,6 +41,7 @@ fun Modifier.handleUserKeyEvent(
     }
 
     return this
+        .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
         .focusRequester(focusRequester)
         .focusable()
         .onPreviewKeyEvent { event ->

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
@@ -1,3 +1,4 @@
+
 package uk.nktnet.webviewkiosk.utils
 
 import android.content.Context
@@ -10,6 +11,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import kotlinx.coroutines.android.awaitFrame
 import uk.nktnet.webviewkiosk.states.UserInteractionStateSingleton
 
 fun Modifier.handleUserTouchEvent(): Modifier {
@@ -20,11 +22,15 @@ fun Modifier.handleUserTouchEvent(): Modifier {
 }
 
 @Composable
-fun Modifier.handleUserKeyEvent(context: Context, isVisible: Boolean): Modifier {
+fun Modifier.handleUserKeyEvent(
+    context: Context,
+    isVisible: Boolean
+): Modifier {
     val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(isVisible) {
         if (isVisible) {
+            awaitFrame()
             focusRequester.requestFocus()
         }
     }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
@@ -53,7 +53,7 @@ object WebViewNavigation {
     }
 
     fun navigateToIndex(customLoadUrl: (newUrl: String) -> Unit, systemSettings: SystemSettings, index: Int) {
-        if (index in 0..systemSettings.historyStack.lastIndex) {
+        if (index in systemSettings.historyStack.indices) {
             isProgrammaticNavigation = true
             systemSettings.historyIndex = index
             customLoadUrl(systemSettings.historyStack[index].url)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/WebviewNavigation.kt
@@ -52,7 +52,11 @@ object WebViewNavigation {
         }
     }
 
-    fun navigateToIndex(customLoadUrl: (newUrl: String) -> Unit, systemSettings: SystemSettings, index: Int) {
+    fun navigateToIndex(
+        customLoadUrl: (newUrl: String) -> Unit,
+        systemSettings: SystemSettings,
+        index: Int,
+    ) {
         if (index in systemSettings.historyStack.indices) {
             isProgrammaticNavigation = true
             systemSettings.historyIndex = index

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.1"
+agp = "9.2.0"
 androidRetrofix = "1.1.0"
 androidRetrostreams = "1.7.4"
 appcompat = "1.7.1"


### PR DESCRIPTION
Potentially resolves #228.

Crash log from Google Play Console:

```
Exception java.lang.IllegalStateException: Expected BringIntoViewRequester to not be used before parents are placed.
  at androidx.compose.foundation.internal.InlineClassHelperKt.throwIllegalStateException (InlineClassHelper.kt:26)
  at androidx.compose.foundation.gestures.ContentInViewNode.calculateRectForParent (ContentInViewNode.java:473)
  at androidx.compose.foundation.relocation.BringIntoViewResponderNode.bringIntoView$lambda$1 (BringIntoViewResponderNode.java:173)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt$bringIntoView$2.invoke (BringIntoViewModifierNode.kt:72)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt$bringIntoView$2.invoke (BringIntoViewModifierNode.kt:67)
  at androidx.compose.ui.platform.BringIntoViewOnScreenResponderNode.bringIntoView (AndroidComposeView.android.kt:3296)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt.bringIntoView (BringIntoViewModifierNode.kt:67)
  at androidx.compose.foundation.relocation.BringIntoViewResponderNode$bringIntoView$2$2.invokeSuspend (BringIntoViewResponderNode.java:191)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:104)
  at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch (AndroidUiDispatcher.android.kt:79)
  at androidx.compose.ui.platform.AndroidUiDispatcher.access$performTrampolineDispatch (AndroidUiDispatcher.android.kt:41)
  at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.run (AndroidUiDispatcher.android.kt:57)
  at android.os.Handler.handleCallback (Handler.java:751)
  at android.os.Handler.dispatchMessage (Handler.java:95)
  at android.os.Looper.loop (Looper.java:154)
  at android.app.ActivityThread.main (ActivityThread.java:6186)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:889)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:779)
```