### PR TITLE
fix: user interaction illegal state exception with snapshots

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/handlers/DimScreenOnInactivityTimeoutHandler.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/handlers/DimScreenOnInactivityTimeoutHandler.kt
@@ -3,6 +3,7 @@ package uk.nktnet.webviewkiosk.handlers
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -24,7 +25,7 @@ fun DimScreenOnInactivityTimeoutHandler() {
         Constants.MIN_INACTIVITY_TIMEOUT_SECONDS
     ) * 1000L
 
-    val lastInteraction by UserInteractionStateSingleton.lastInteractionState
+    val lastInteraction by UserInteractionStateSingleton.lastInteractionState.collectAsState()
 
     LaunchedEffect(lastInteraction) {
         setWindowBrightness(context, userSettings.brightness)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/handlers/ResetOnInactivityTimeoutHandler.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/handlers/ResetOnInactivityTimeoutHandler.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -47,7 +48,7 @@ fun ResetOnInactivityTimeoutHandler(
     val countdownStartDuration = timeoutDuration - Constants.INACTIVITY_COUNTDOWN_SECONDS * 1000L
     var countdown by remember { mutableIntStateOf(RESET_TIMEOUT_INT) }
 
-    val lastInteraction by UserInteractionStateSingleton.lastInteractionState
+    val lastInteraction by UserInteractionStateSingleton.lastInteractionState.collectAsState()
 
     val handleTimeoutReached = {
         systemSettings.clearHistory()

--- a/app/src/main/java/uk/nktnet/webviewkiosk/states/UserInteractionStateSingleton.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/states/UserInteractionStateSingleton.kt
@@ -1,14 +1,17 @@
 package uk.nktnet.webviewkiosk.states
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableLongStateOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 object UserInteractionStateSingleton {
-    val lastInteractionState: MutableState<Long> = mutableLongStateOf(
-        System.currentTimeMillis()
-    )
+    private val _lastInteraction =
+        MutableStateFlow(System.currentTimeMillis())
+
+    val lastInteractionState: StateFlow<Long> =
+        _lastInteraction.asStateFlow()
 
     fun onUserInteraction() {
-        lastInteractionState.value = System.currentTimeMillis()
+        _lastInteraction.value = System.currentTimeMillis()
     }
 }


### PR DESCRIPTION
Addressing:

```
  FATAL EXCEPTION: main
  Process: uk.nktnet.webviewkiosk, PID: 1829
  java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied
    at androidx.compose.runtime.snapshots.SnapshotKt.readError(Snapshot.kt:2108)
    at androidx.compose.runtime.snapshots.SnapshotKt.readable(Snapshot.kt:2083)
    at androidx.compose.runtime.SnapshotMutableLongStateImpl.getLongValue(SnapshotLongState.kt:142)
    at androidx.compose.runtime.MutableLongState.getValue(SnapshotLongState.kt:97)
    at androidx.compose.runtime.MutableLongState.getValue(SnapshotLongState.kt:91)
    at uk.nktnet.webviewkiosk.handlers.DimScreenOnInactivityTimeoutHandlerKt.DimScreenOnInactivityTimeoutHandler$lambda$1(DimScreenOnInactivityTimeoutHandler.kt:64)
    at uk.nktnet.webviewkiosk.handlers.DimScreenOnInactivityTimeoutHandlerKt.DimScreenOnInactivityTimeoutHandler(DimScreenOnInactivityTimeoutHandler.kt:29)
    at uk.nktnet.webviewkiosk.ui.screens.WebviewScreenKt.WebviewScreen(WebviewScreen.kt:537)
    at uk.nktnet.webviewkiosk.ui.screens.SetupNavHostKt.SetupNavHost$lambda$26$0$0(SetupNavHost.kt:64)
    at uk.nktnet.webviewkiosk.ui.screens.SetupNavHostKt.$r8$lambda$Nw4cMIq8ZWGzczISgbUlFRz_n3c(Unknown Source:0)
    at uk.nktnet.webviewkiosk.ui.screens.SetupNavHostKt$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
```