### PR TITLE
fix: illegal state exception from BringIntoViewRequester

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/auth/CustomAuthPasswordDialog.kt
@@ -73,7 +73,9 @@ fun CustomAuthPasswordDialog() {
     LaunchedEffect(Unit) {
         delay(100.milliseconds)
         awaitFrame()
-        focusRequester.requestFocus()
+        runCatching {
+            focusRequester.requestFocus()
+        }
     }
 
     fun handleUnlock() {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/device/CustomUnlockShortcutSetting.kt
@@ -86,7 +86,9 @@ fun CustomUnlockShortcutSetting() {
             coroutineScope.launch {
                 delay(100.milliseconds)
                 awaitFrame()
-                focusRequester.requestFocus()
+                runCatching {
+                    focusRequester.requestFocus()
+                }
             }
         }
     }
@@ -172,7 +174,9 @@ fun CustomUnlockShortcutSetting() {
                             coroutineScope.launch {
                                 delay(100.milliseconds)
                                 awaitFrame()
-                                focusRequester.requestFocus()
+                                runCatching {
+                                    focusRequester.requestFocus()
+                                }
                             }
                         }
                     },

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/WebViewFindBar.kt
@@ -92,7 +92,9 @@ fun WebViewFindBar(
         if (isActiveFindInPage) {
             delay(100.milliseconds)
             awaitFrame()
-            focusRequester.requestFocus()
+            runCatching {
+                focusRequester.requestFocus()
+            }
         }
     }
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -160,7 +160,9 @@ fun WebviewScreen(navController: NavController) {
             scope.launch {
                 delay(100.milliseconds)
                 awaitFrame()
-                findInPageFocusRequester.requestFocus()
+                runCatching {
+                    findInPageFocusRequester.requestFocus()
+                }
             }
         }
     }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -147,7 +147,9 @@ fun createCustomWebview(
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     config.setLastErrorUrl("")
                     if (userSettings.requestFocusOnPageStart) {
-                        view?.requestFocus()
+                        runCatching {
+                            view?.requestFocus()
+                        }
                     }
                     if (userSettings.applyAppTheme && userSettings.theme != ThemeOption.SYSTEM) {
                         evaluateJavascript(

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/modifierUtils.kt
@@ -1,13 +1,12 @@
-
 package uk.nktnet.webviewkiosk.utils
 
 import android.content.Context
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -25,22 +24,23 @@ fun Modifier.handleUserTouchEvent(): Modifier {
     }
 }
 
-@Composable
 fun Modifier.handleUserKeyEvent(
     context: Context,
     isVisible: Boolean
-): Modifier {
+): Modifier = composed {
     val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(isVisible) {
         if (isVisible) {
             delay(100.milliseconds)
             awaitFrame()
-            focusRequester.requestFocus()
+            runCatching {
+                focusRequester.requestFocus()
+            }
         }
     }
 
-    return this
+    this
         .defaultMinSize(minWidth = 1.dp, minHeight = 1.dp)
         .focusRequester(focusRequester)
         .focusable()

--- a/docs/content/docs/settings/mqtt/index.mdx
+++ b/docs/content/docs/settings/mqtt/index.mdx
@@ -49,7 +49,6 @@ Our recommendation for open source, self-hostable brokers (server) and clients
    [Home Assistant](https://github.com/home-assistant) - see the
    [Integration Guide](https://www.home-assistant.io/integrations/mqtt)
 
-
    <Callout title="Tip" type="info">
 
       Here is a third-party integration with Home Assistant:
@@ -59,7 +58,6 @@ Our recommendation for open source, self-hostable brokers (server) and clients
       This project is community-built and not maintained by Webview Kiosk.
 
    </Callout>
-
 
 There are also public brokers you can use for testing purposes, such as
 - HiveMQ: https://www.mqtt-dashboard.com


### PR DESCRIPTION
Another attempt at resolving #228.

Supersedes #229.

Full stacktrace from Google Play:

```
Exception java.lang.IllegalStateException: Expected BringIntoViewRequester to not be used before parents are placed.
  at androidx.compose.foundation.internal.InlineClassHelperKt.throwIllegalStateException (InlineClassHelper.kt:26)
  at androidx.compose.foundation.gestures.ContentInViewNode.calculateRectForParent (ContentInViewNode.java:473)
  at androidx.compose.foundation.relocation.BringIntoViewResponderNode.bringIntoView$lambda$1 (BringIntoViewResponderNode.java:173)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt$bringIntoView$2.invoke (BringIntoViewModifierNode.kt:72)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt$bringIntoView$2.invoke (BringIntoViewModifierNode.kt:67)
  at androidx.compose.ui.platform.BringIntoViewOnScreenResponderNode.bringIntoView (AndroidComposeView.android.kt:3296)
  at androidx.compose.ui.relocation.BringIntoViewModifierNodeKt.bringIntoView (BringIntoViewModifierNode.kt:67)
  at androidx.compose.foundation.relocation.BringIntoViewResponderNode$bringIntoView$2$2.invokeSuspend (BringIntoViewResponderNode.java:191)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:104)
  at androidx.compose.ui.platform.AndroidUiDispatcher.performTrampolineDispatch (AndroidUiDispatcher.android.kt:79)
  at androidx.compose.ui.platform.AndroidUiDispatcher.access$performTrampolineDispatch (AndroidUiDispatcher.android.kt:41)
  at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.run (AndroidUiDispatcher.android.kt:57)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7945)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:603)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:947)
```

Sample Attributes:
- Premier TAB-7887-32G3GB
- Android 11 (SDK 30)
- Version: 124 (0.26.10)
