### PR TITLE
fix(theme): immersive mode overwriting system bar styles

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -4,10 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.WindowManager
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -103,8 +105,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
         CustomNotificationManager.init(applicationContext)
         userSettings = UserSettings(this)
         systemSettings = SystemSettings(this)
@@ -246,12 +248,27 @@ class MainActivity : AppCompatActivity() {
             val isDarkTheme = resolveTheme(ThemeStateSingleton.currentTheme.value)
             val window = (this as? AppCompatActivity)?.window
             val insetsController = remember(window) {
-                window?.let { WindowInsetsControllerCompat(it, it.decorView) }
+                window?.let {
+                    WindowInsetsControllerCompat(it, it.decorView)
+                }
             }
 
             LaunchedEffect(isDarkTheme) {
                 insetsController?.isAppearanceLightStatusBars = !isDarkTheme
                 insetsController?.isAppearanceLightNavigationBars = !isDarkTheme
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    window?.run {
+                        addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+                        @Suppress("DEPRECATION")
+                        if (!isDarkTheme) {
+                            statusBarColor = Color.WHITE
+                            navigationBarColor = Color.WHITE
+                        } else {
+                            statusBarColor = Color.BLACK
+                            navigationBarColor = Color.BLACK
+                        }
+                    }
+                }
             }
 
             WebviewKioskTheme(darkTheme = isDarkTheme) {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/theme/Theme.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/theme/Theme.kt
@@ -42,7 +42,11 @@ fun WebviewKioskTheme(
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            if (darkTheme) {
+                dynamicDarkColorScheme(context)
+            } else {
+                dynamicLightColorScheme(context)
+            }
         }
 
         darkTheme -> DarkColorScheme

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/immersiveUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/immersiveUtils.kt
@@ -20,6 +20,7 @@ fun shouldBeImmersed(activity: Activity, userSettings: UserSettings): Boolean {
     }
 }
 
+@Suppress("DEPRECATION")
 fun enterImmersiveMode(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         activity.window.insetsController?.let { controller ->
@@ -31,26 +32,38 @@ fun enterImmersiveMode(activity: Activity) {
                 WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
     } else {
-        @Suppress("DEPRECATION")
-        activity.window.decorView.systemUiVisibility = (
+        val decorView = activity.window.decorView
+        val currentFlags = decorView.systemUiVisibility
+        val immersiveFlags = (
             View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-            or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-            or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-            or View.SYSTEM_UI_FLAG_FULLSCREEN
-            or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
         )
+        decorView.systemUiVisibility = currentFlags or immersiveFlags
     }
 }
 
+@Suppress("DEPRECATION")
 fun exitImmersiveMode(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         activity.window.insetsController?.show(
             WindowInsets.Type.statusBars()
             or WindowInsets.Type.navigationBars()
         )
+
     } else {
-        @Suppress("DEPRECATION")
-        activity.window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+        val decorView = activity.window.decorView
+        val currentFlags = decorView.systemUiVisibility
+        val flagsToRemove = (
+            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        )
+        decorView.systemUiVisibility = currentFlags and flagsToRemove.inv()
     }
 }


### PR DESCRIPTION
Immersive mode was overwriting the colours of the navigation and status bars for Android versions 10 and below.