### PR TITLE
fix(auth): bypass auth for window when launching activities

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
@@ -34,7 +34,7 @@ object AuthenticationManager {
 
     private var encryptedAuthToken: ByteArray? = null
     private var encryptedAuthTokenIv: ByteArray? = null
-    private const val SKIP_RESET_WINDOW_MS = 5000L
+    private const val BYPASS_AUTH_WINDOW_MS = 5000L
 
     private var activity: AppCompatActivity? = null
 
@@ -46,7 +46,7 @@ object AuthenticationManager {
     val showCustomAuth: MutableState<Boolean> = mutableStateOf(false)
 
     private var lastAuthTime = 0L
-    private var skipResetUntil: Long = 0L
+    private var authBypassUntil: Long = 0L
 
     fun init(activity: AppCompatActivity) {
         this.activity = activity
@@ -54,27 +54,23 @@ object AuthenticationManager {
 
     fun checkAuthAndRefreshSession(): Boolean {
         val now = System.currentTimeMillis()
+        if (now <= authBypassUntil) {
+            return true
+        }
         val isValid = now - lastAuthTime < AUTH_TIMEOUT_MS
         if (isValid) {
             lastAuthTime = now
         }
-        skipResetUntil = 0L
+        authBypassUntil = 0L
         return isValid
     }
 
     fun resetAuthentication() {
-        val now = System.currentTimeMillis()
-        if (now <= skipResetUntil) {
-            skipResetUntil = 0L
-            return
-        }
         lastAuthTime = 0
     }
 
-    fun skipNextAuthResetForWindow() {
-        val now = System.currentTimeMillis()
-        skipResetUntil = now + SKIP_RESET_WINDOW_MS
-        lastAuthTime = now
+    fun bypassAuthForWindow() {
+        authBypassUntil = System.currentTimeMillis() + BYPASS_AUTH_WINDOW_MS
     }
 
     fun showAuthenticationPrompt(
@@ -120,7 +116,7 @@ object AuthenticationManager {
     private fun handleAuthSuccess() {
         _resultState.value = AuthenticationResult.AuthenticationSuccess
         lastAuthTime = System.currentTimeMillis()
-        skipNextAuthResetForWindow()
+        bypassAuthForWindow()
     }
 
     @RequiresApi(Build.VERSION_CODES.M)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
@@ -54,10 +54,10 @@ object AuthenticationManager {
 
     fun checkAuthAndRefreshSession(): Boolean {
         val now = System.currentTimeMillis()
-        if (now <= authBypassUntil) {
-            return true
-        }
-        val isValid = now - lastAuthTime < AUTH_TIMEOUT_MS
+        val isValid = (
+            now <= authBypassUntil
+            || now - lastAuthTime < AUTH_TIMEOUT_MS
+        )
         if (isValid) {
             lastAuthTime = now
         }
@@ -69,8 +69,8 @@ object AuthenticationManager {
         lastAuthTime = 0
     }
 
-    fun bypassAuthForWindow() {
-        authBypassUntil = System.currentTimeMillis() + BYPASS_AUTH_WINDOW_MS
+    fun bypassAuthForWindow(durationMs: Long = BYPASS_AUTH_WINDOW_MS) {
+        authBypassUntil = System.currentTimeMillis() + durationMs
     }
 
     fun showAuthenticationPrompt(

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/dialog/ExportSettingDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/dialog/ExportSettingDialog.kt
@@ -186,7 +186,7 @@ fun ExportSettingsDialog(
                             scope.launch {
                                 try {
                                     exportLauncher.launch("wk_user_settings")
-                                    AuthenticationManager.skipNextAuthResetForWindow()
+                                    AuthenticationManager.bypassAuthForWindow()
                                 } catch (e: Exception) {
                                     Log.e(
                                         Constants.APP_SCHEME,

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/dialog/ImportSettingDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/dialog/ImportSettingDialog.kt
@@ -195,7 +195,7 @@ fun ImportSettingsDialog(
                                 fileLauncher.launch(
                                     arrayOf("text/plain", "application/json")
                                 )
-                                AuthenticationManager.skipNextAuthResetForWindow()
+                                AuthenticationManager.bypassAuthForWindow()
                             } catch (e: Exception) {
                                 Log.e(
                                     Constants.APP_SCHEME,

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
@@ -131,7 +131,7 @@ fun SettingsWebContentFilesScreen(navController: NavController) {
                     onClick = {
                         try {
                             fileUploadLauncher.launch(supportedMimeTypesArray)
-                            AuthenticationManager.skipNextAuthResetForWindow()
+                            AuthenticationManager.bypassAuthForWindow()
                         } catch (e: Exception) {
                             Log.e(Constants.APP_SCHEME, "File picker failed to launch", e)
                             ToastManager.show(context, "Error: ${e.message}")

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
@@ -131,7 +131,7 @@ fun SettingsWebContentFilesScreen(navController: NavController) {
                     onClick = {
                         try {
                             fileUploadLauncher.launch(supportedMimeTypesArray)
-                            AuthenticationManager.bypassAuthForWindow(30_000)
+                            AuthenticationManager.bypassAuthForWindow(60_000)
                         } catch (e: Exception) {
                             Log.e(Constants.APP_SCHEME, "File picker failed to launch", e)
                             ToastManager.show(context, "Error: ${e.message}")

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/SettingsWebContentFilesScreen.kt
@@ -131,7 +131,7 @@ fun SettingsWebContentFilesScreen(navController: NavController) {
                     onClick = {
                         try {
                             fileUploadLauncher.launch(supportedMimeTypesArray)
-                            AuthenticationManager.bypassAuthForWindow()
+                            AuthenticationManager.bypassAuthForWindow(30_000)
                         } catch (e: Exception) {
                             Log.e(Constants.APP_SCHEME, "File picker failed to launch", e)
                             ToastManager.show(context, "Error: ${e.message}")

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/openIntentUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/openIntentUtils.kt
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import uk.nktnet.webviewkiosk.config.Constants
 import uk.nktnet.webviewkiosk.config.UserSettings
+import uk.nktnet.webviewkiosk.managers.AuthenticationManager
 import uk.nktnet.webviewkiosk.managers.ToastManager
 import uk.nktnet.webviewkiosk.services.LockTaskService
 
@@ -24,6 +25,7 @@ fun safeStartActivity(context: Context, intent: Intent, bundle: Bundle? = null) 
     try {
         if (intent.resolveActivity(context.packageManager) != null) {
             context.startActivity(intent, bundle)
+            AuthenticationManager.bypassAuthForWindow()
         } else {
             val shortName = intent.action?.substringAfterLast('.') ?: "Unknown"
             ToastManager.show(


### PR DESCRIPTION
Allow auth to be skipped when launching another app or setting (thus putting Webview Kiosk in the background), then returning within a short duration (5 seconds default, 60 seconds for file upload).