### PR TITLE
feat(docs): make legal pages searchable

### DIFF
--- a/docs/src/routes/api/search.ts
+++ b/docs/src/routes/api/search.ts
@@ -1,10 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { createFromSource } from "fumadocs-core/search/server";
-import { source } from "@/lib/source";
+import { createSearchAPI } from "fumadocs-core/search/server";
+import { legal, source } from "@/lib/source";
 
-const server = createFromSource(source, {
+const pages = source.getPages().concat(legal.getPages());
+
+const server = createSearchAPI("advanced", {
   // https://docs.orama.com/docs/orama-js/supported-languages
   language: "english",
+  indexes: pages.map((page) => ({
+    id: page.url,
+    title: page.data.title,
+    description: page.data.description,
+    structuredData: page.data.structuredData,
+    url: page.url,
+  })),
 });
 
 export const Route = createFileRoute("/api/search")({


### PR DESCRIPTION
Allow the "Privacy" and the "Terms & Conditions" pages to be indexed and searchable.

Docs:

- https://www.fumadocs.dev/docs/headless/search/orama#from-search-indexes