### PR TITLE
docs: allow codeblocks to be indexed and searchable

### DIFF
--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -58,6 +58,16 @@ export const legal = defineCollections({
 export default defineConfig({
   plugins: [lastModified()],
   mdxOptions: {
+    remarkStructureOptions: {
+      types: [
+        "heading",
+        "paragraph",
+        "blockquote",
+        "tableCell",
+        "mdxJsxFlowElement",
+        "code",
+      ],
+    },
     remarkPlugins: [
       [
         remarkReplaceConstants,


### PR DESCRIPTION
Add `"code"` to the `mdxOptions.remarkStructureOptions.types` array in `source.config.ts`.

See: https://github.com/fuma-nama/fumadocs/discussions/3388