### PR TITLE
fix: NFC stops scanning when screen turned off

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -356,7 +356,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onPause() {
         disableNfcReaderMode()
-        NfcBridgeManager.setScanActive(false)
         super.onPause()
     }
 


### PR DESCRIPTION
Currently NFC stops scanning when the screen turns off but does not restart when the screen turns back on. This change keeps isScanActive True so that when the screen and NFC turn back on scanning automatically restarts.