### PR TITLE
feat: open camera or voice recorder for HTML <input capture> - photo/video/audio uploads

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/config/Constants.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/config/Constants.kt
@@ -17,6 +17,7 @@ object Constants {
 
     const val APP_SCHEME = "webviewkiosk"
     const val GEOLOCATION_RESOURCE = "${APP_SCHEME}.custom-permission.geolocation"
+    const val FILE_CAPTURE_CACHE_PATH_NAME = "capture"
 
     const val INTENT_NAVIGATE_TO_WEBVIEW_SCREEN = "intent_navigate_to_webview_screen"
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -1,13 +1,16 @@
 package uk.nktnet.webviewkiosk.utils
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.net.Uri
 import android.net.http.SslError
 import android.os.Build
+import android.provider.MediaStore
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
@@ -31,6 +34,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewCompat
@@ -103,6 +108,66 @@ fun createCustomWebview(
         }
         pendingFileChooserCallback?.onReceiveValue(uris)
         pendingFileChooserCallback = null
+    }
+
+    var pendingCaptureUri by remember { mutableStateOf<Uri?>(null) }
+    var pendingCaptureRequest by remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    val cameraCaptureLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val captured = result.data?.data ?: pendingCaptureUri
+        if (result.resultCode == Activity.RESULT_OK && captured != null) {
+            pendingFileChooserCallback?.onReceiveValue(arrayOf(captured))
+        } else {
+            pendingFileChooserCallback?.onReceiveValue(null)
+        }
+        pendingFileChooserCallback = null
+        pendingCaptureUri = null
+    }
+
+    fun launchMediaCapture(action: String, fileSuffix: String) {
+        runCatching {
+            val captureDir = File(context.cacheDir, "capture").apply { mkdirs() }
+            val outputFile = File.createTempFile("capture_", fileSuffix, captureDir)
+            val outputUri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                outputFile
+            )
+            pendingCaptureUri = outputUri
+            val captureIntent = Intent(action).apply {
+                putExtra(MediaStore.EXTRA_OUTPUT, outputUri)
+                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            }
+            if (captureIntent.resolveActivity(context.packageManager) != null) {
+                cameraCaptureLauncher.launch(captureIntent)
+            } else {
+                ToastManager.show(context, "No camera app is available on this device.")
+                pendingFileChooserCallback?.onReceiveValue(null)
+                pendingFileChooserCallback = null
+                pendingCaptureUri = null
+            }
+        }.onFailure {
+            ToastManager.show(context, "Could not open the camera.")
+            pendingFileChooserCallback?.onReceiveValue(null)
+            pendingFileChooserCallback = null
+            pendingCaptureUri = null
+        }
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val request = pendingCaptureRequest
+        pendingCaptureRequest = null
+        if (granted && request != null) {
+            launchMediaCapture(request.first, request.second)
+        } else {
+            ToastManager.show(context, "Camera permission is required to capture a photo or video.")
+            pendingFileChooserCallback?.onReceiveValue(null)
+            pendingFileChooserCallback = null
+        }
     }
 
     fun buildWebView(): WebView {
@@ -548,8 +613,37 @@ fun createCustomWebview(
                             "File picker is disabled in ${context.getString(R.string.app_name)}'s Web Engine settings."
                         )
                         filePathCallback.onReceiveValue(null)
+                        return true
+                    }
+
+                    pendingFileChooserCallback = filePathCallback
+
+                    // Honour the HTML `capture` attribute: when a page requests capture from an
+                    // image/video input (e.g. <input type="file" accept="image/*" capture>), open
+                    // the device camera app instead of the document picker. Gated behind the
+                    // existing "Allow camera" setting; falls back to the normal picker otherwise.
+                    val acceptTypes = fileChooserParams.acceptTypes.filter { it.isNotBlank() }
+                    val wantsImage = acceptTypes.isEmpty() ||
+                        acceptTypes.any { it.startsWith("image/") || it == "*/*" }
+                    val wantsVideo = acceptTypes.any { it.startsWith("video/") }
+                    val captureRequest = when {
+                        !fileChooserParams.isCaptureEnabled || !config.userSettings.allowCamera -> null
+                        wantsVideo && !wantsImage -> MediaStore.ACTION_VIDEO_CAPTURE to ".mp4"
+                        wantsImage -> MediaStore.ACTION_IMAGE_CAPTURE to ".jpg"
+                        else -> null
+                    }
+
+                    if (captureRequest != null) {
+                        if (
+                            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+                            == PackageManager.PERMISSION_GRANTED
+                        ) {
+                            launchMediaCapture(captureRequest.first, captureRequest.second)
+                        } else {
+                            pendingCaptureRequest = captureRequest
+                            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                        }
                     } else {
-                        pendingFileChooserCallback = filePathCallback
                         val intent = fileChooserParams.createIntent()
                         if (fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
                             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -111,7 +111,6 @@ fun createCustomWebview(
     }
 
     var pendingCaptureUri by remember { mutableStateOf<Uri?>(null) }
-    var pendingCaptureRequest by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     val cameraCaptureLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -128,8 +127,17 @@ fun createCustomWebview(
 
     fun launchMediaCapture(action: String, fileSuffix: String) {
         runCatching {
-            val captureDir = File(context.cacheDir, "capture").apply { mkdirs() }
-            val outputFile = File.createTempFile("capture_", fileSuffix, captureDir)
+            val captureDir = File(
+                context.cacheDir,
+                Constants.FILE_CAPTURE_CACHE_PATH_NAME
+            ).apply {
+                mkdirs()
+            }
+            val outputFile = File.createTempFile(
+                "${Constants.FILE_CAPTURE_CACHE_PATH_NAME}_",
+                fileSuffix,
+                captureDir
+            )
             val outputUri = FileProvider.getUriForFile(
                 context,
                 "${context.packageName}.provider",
@@ -153,20 +161,6 @@ fun createCustomWebview(
             pendingFileChooserCallback?.onReceiveValue(null)
             pendingFileChooserCallback = null
             pendingCaptureUri = null
-        }
-    }
-
-    val cameraPermissionLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
-        val request = pendingCaptureRequest
-        pendingCaptureRequest = null
-        if (granted && request != null) {
-            launchMediaCapture(request.first, request.second)
-        } else {
-            ToastManager.show(context, "Camera permission is required to capture a photo or video.")
-            pendingFileChooserCallback?.onReceiveValue(null)
-            pendingFileChooserCallback = null
         }
     }
 
@@ -618,31 +612,33 @@ fun createCustomWebview(
 
                     pendingFileChooserCallback = filePathCallback
 
-                    // Honour the HTML `capture` attribute: when a page requests capture from an
-                    // image/video input (e.g. <input type="file" accept="image/*" capture>), open
-                    // the device camera app instead of the document picker. Gated behind the
-                    // existing "Allow camera" setting; falls back to the normal picker otherwise.
+                    /**
+                     * Honour the HTML `capture` attribute: when a page requests capture from an
+                     * image/video input (e.g. <input type="file" accept="image/\*" capture>), open
+                     * the device camera app instead of the document picker. Gated behind the
+                     * existing "Allow camera" setting; falls back to the normal picker otherwise.
+                     */
                     val acceptTypes = fileChooserParams.acceptTypes.filter { it.isNotBlank() }
-                    val wantsImage = acceptTypes.isEmpty() ||
-                        acceptTypes.any { it.startsWith("image/") || it == "*/*" }
+                    val wantsImage = acceptTypes.any { it.startsWith("image/") }
                     val wantsVideo = acceptTypes.any { it.startsWith("video/") }
                     val captureRequest = when {
-                        !fileChooserParams.isCaptureEnabled || !config.userSettings.allowCamera -> null
-                        wantsVideo && !wantsImage -> MediaStore.ACTION_VIDEO_CAPTURE to ".mp4"
+                        !(
+                            fileChooserParams.isCaptureEnabled
+                            && config.userSettings.allowCamera
+                            && ContextCompat.checkSelfPermission(
+                                    context,
+                                    Manifest.permission.CAMERA
+                               ) == PackageManager.PERMISSION_GRANTED
+                        ) -> null
                         wantsImage -> MediaStore.ACTION_IMAGE_CAPTURE to ".jpg"
+                        wantsVideo -> MediaStore.ACTION_VIDEO_CAPTURE to ".mp4"
                         else -> null
                     }
-
                     if (captureRequest != null) {
-                        if (
-                            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
-                            == PackageManager.PERMISSION_GRANTED
-                        ) {
-                            launchMediaCapture(captureRequest.first, captureRequest.second)
-                        } else {
-                            pendingCaptureRequest = captureRequest
-                            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
-                        }
+                        launchMediaCapture(
+                            captureRequest.first,
+                            captureRequest.second,
+                        )
                     } else {
                         val intent = fileChooserParams.createIntent()
                         if (fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -112,7 +112,7 @@ fun createCustomWebview(
 
     var pendingCaptureUri by remember { mutableStateOf<Uri?>(null) }
 
-    val cameraCaptureLauncher = rememberLauncherForActivityResult(
+    val captureLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         val captured = result.data?.data ?: pendingCaptureUri
@@ -125,7 +125,7 @@ fun createCustomWebview(
         pendingCaptureUri = null
     }
 
-    fun launchMediaCapture(action: String, fileSuffix: String) {
+    fun customLaunchCapture(action: String, fileSuffix: String) {
         runCatching {
             val captureDir = File(
                 context.cacheDir,
@@ -149,15 +149,15 @@ fun createCustomWebview(
                 addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             }
             if (captureIntent.resolveActivity(context.packageManager) != null) {
-                cameraCaptureLauncher.launch(captureIntent)
+                captureLauncher.launch(captureIntent)
             } else {
-                ToastManager.show(context, "No camera app is available on this device.")
+                ToastManager.show(context, "No capture app is available on this device.")
                 pendingFileChooserCallback?.onReceiveValue(null)
                 pendingFileChooserCallback = null
                 pendingCaptureUri = null
             }
         }.onFailure {
-            ToastManager.show(context, "Could not open the camera.")
+            ToastManager.show(context, "Could not open the capture.")
             pendingFileChooserCallback?.onReceiveValue(null)
             pendingFileChooserCallback = null
             pendingCaptureUri = null
@@ -621,21 +621,50 @@ fun createCustomWebview(
                     val acceptTypes = fileChooserParams.acceptTypes.filter { it.isNotBlank() }
                     val wantsImage = acceptTypes.any { it.startsWith("image/") }
                     val wantsVideo = acceptTypes.any { it.startsWith("video/") }
+                    val wantsAudio = acceptTypes.any { it.startsWith("audio/") }
+
+                    val hasCameraPermission =
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.CAMERA,
+                        ) == PackageManager.PERMISSION_GRANTED
+
+                    val hasAudioPermission =
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.RECORD_AUDIO,
+                        ) == PackageManager.PERMISSION_GRANTED
+
                     val captureRequest = when {
-                        !(
-                            fileChooserParams.isCaptureEnabled
+                        !fileChooserParams.isCaptureEnabled -> null
+                        (
+                            wantsImage
                             && config.userSettings.allowCamera
-                            && ContextCompat.checkSelfPermission(
-                                    context,
-                                    Manifest.permission.CAMERA
-                               ) == PackageManager.PERMISSION_GRANTED
-                        ) -> null
-                        wantsImage -> MediaStore.ACTION_IMAGE_CAPTURE to ".jpg"
-                        wantsVideo -> MediaStore.ACTION_VIDEO_CAPTURE to ".mp4"
-                        else -> null
+                            && hasCameraPermission
+                        ) -> {
+                            MediaStore.ACTION_IMAGE_CAPTURE to ".jpg"
+                        }
+                        (
+                            wantsVideo
+                            && config.userSettings.allowCamera
+                            && hasCameraPermission
+                        ) -> {
+                            MediaStore.ACTION_VIDEO_CAPTURE to ".mp4"
+                        }
+                        (
+                            wantsAudio
+                            && config.userSettings.allowMicrophone
+                            && hasAudioPermission
+                        ) -> {
+                            MediaStore.Audio.Media.RECORD_SOUND_ACTION to ".m4a"
+                        }
+                        else -> {
+                            null
+                        }
                     }
+
                     if (captureRequest != null) {
-                        launchMediaCapture(
+                        customLaunchCapture(
                             captureRequest.first,
                             captureRequest.second,
                         )

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -125,7 +125,15 @@ fun createCustomWebview(
         pendingCaptureUri = null
     }
 
-    fun customLaunchCapture(action: String, fileSuffix: String) {
+    fun launchFilePicker(fileChooserParams: WebChromeClient.FileChooserParams) {
+        val intent = fileChooserParams.createIntent()
+        if (fileChooserParams.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE) {
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        }
+        filePickerLauncher.launch(intent)
+    }
+
+    fun customLaunchCapture(action: String, fileSuffix: String): Boolean {
         runCatching {
             val captureDir = File(
                 context.cacheDir,
@@ -150,18 +158,18 @@ fun createCustomWebview(
             }
             if (captureIntent.resolveActivity(context.packageManager) != null) {
                 captureLauncher.launch(captureIntent)
+                return true
             } else {
-                ToastManager.show(context, "No capture app is available on this device.")
                 pendingFileChooserCallback?.onReceiveValue(null)
                 pendingFileChooserCallback = null
                 pendingCaptureUri = null
             }
         }.onFailure {
-            ToastManager.show(context, "Could not open the capture.")
             pendingFileChooserCallback?.onReceiveValue(null)
             pendingFileChooserCallback = null
             pendingCaptureUri = null
         }
+        return false
     }
 
     fun buildWebView(): WebView {
@@ -663,17 +671,16 @@ fun createCustomWebview(
                         }
                     }
 
-                    if (captureRequest != null) {
-                        customLaunchCapture(
+                    val captureHandled = (
+                        captureRequest != null
+                        && customLaunchCapture(
                             captureRequest.first,
                             captureRequest.second,
                         )
-                    } else {
-                        val intent = fileChooserParams.createIntent()
-                        if (fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
-                            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-                        }
-                        filePickerLauncher.launch(intent)
+                    )
+
+                    if (!captureHandled) {
+                        launchFilePicker(fileChooserParams)
                     }
                     return true
                 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -620,12 +620,6 @@ fun createCustomWebview(
 
                     pendingFileChooserCallback = filePathCallback
 
-                    /**
-                     * Honour the HTML `capture` attribute: when a page requests capture from an
-                     * image/video input (e.g. <input type="file" accept="image/\*" capture>), open
-                     * the device camera app instead of the document picker. Gated behind the
-                     * existing "Allow camera" setting; falls back to the normal picker otherwise.
-                     */
                     val acceptTypes = fileChooserParams.acceptTypes.filter { it.isNotBlank() }
                     val wantsImage = acceptTypes.any { it.startsWith("image/") }
                     val wantsVideo = acceptTypes.any { it.startsWith("video/") }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,3 +1,4 @@
 <paths>
     <external-path name="downloads" path="Download/" />
+    <cache-path name="captures" path="capture/" />
 </paths>


### PR DESCRIPTION
`onShowFileChooser` used `FileChooserParams.createIntent()`, which ignores the HTML `capture` attribute — so `<input type="file" accept="image/*" capture>` opened the document/gallery picker instead of the camera.

This honours `FileChooserParams.isCaptureEnabled` and launches the camera app (`ACTION_IMAGE_CAPTURE`, or `ACTION_VIDEO_CAPTURE` for video-only inputs) through the `FileProvider` already declared in the manifest, returning the captured file to the input. Gated behind the existing **Allow camera** setting, so it's opt-in and non-breaking — the normal picker is still used when `capture` isn't requested or the camera is disabled.

Built against the API 37 SDK and installed on an Android 13 device.
