### PR TITLE
fix: only apply ime padding for Android 11+ or 8.1 and below

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -2,6 +2,7 @@ package uk.nktnet.webviewkiosk.ui.screens
 
 import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.util.Base64
 import android.util.Log
 import android.webkit.CookieManager
@@ -108,6 +109,15 @@ import uk.nktnet.webviewkiosk.utils.webview.resolveUrlOrSearch
 import java.io.File
 import java.net.URL
 import kotlin.time.Duration.Companion.milliseconds
+
+fun Modifier.imePaddingCompat(): Modifier = if (
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+    || Build.VERSION.SDK_INT <= Build.VERSION_CODES.P
+) {
+    this.imePadding()
+} else {
+    this
+}
 
 @Composable
 fun WebviewScreen(navController: NavController) {
@@ -502,7 +512,7 @@ fun WebviewScreen(navController: NavController) {
         modifier = Modifier
             .fillMaxSize()
             .windowInsetsPadding(userSettings.webViewInset.toWindowInsets())
-            .imePadding()
+            .imePaddingCompat()
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             if (showAddressBar && userSettings.addressBarPosition == AddressBarPositionOption.TOP) {


### PR DESCRIPTION
Apply ime padding in jetpack compose from Android 11 (API 30) onwards, or Android 8.1 (API 27) and below.

---

- Resolves #259 (CC @sfowlr)
- Resolves #260 (CC @quieronaduchafria) 
