### PR TITLE
feat: support titles in bookmarks

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webcontent/WebsiteBookmarksSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webcontent/WebsiteBookmarksSetting.kt
@@ -55,7 +55,19 @@ fun WebsiteBookmarksSetting() {
         restricted = restricted,
         isMultiline = true,
         validator = { input ->
-            input.isEmpty() || input.lines().all { validateUrl(it.trim()) }
+            input.isEmpty() || input.lines().all { line ->
+                val trimmedLine = line.trim()
+
+                if (trimmedLine.count { it == '|' } > 1) {
+                    false
+                } else {
+                    val url = trimmedLine
+                        .substringBefore('|')
+                        .trim()
+
+                    validateUrl(url)
+                }
+            }
         },
         validationMessage = "Some lines contain invalid URLs",
         onSave = { input ->

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webcontent/WebsiteBookmarksSetting.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/setting/fielditems/webcontent/WebsiteBookmarksSetting.kt
@@ -42,13 +42,32 @@ fun WebsiteBookmarksSetting() {
     TextSettingFieldItem(
         label = stringResource(R.string.web_content_website_bookmarks_title ),
         infoText = """
-            Add your bookmark URLs, one per line.
-            You can access the bookmarks using the address bar menu.
+            Specify bookmarked URLs one per line. Blank lines will be ignored.
+            
+            This is accessible in the address bar. See the relevant setting "Web Browsing -> Allow Bookmark Access".
+            
+            You can also specify a title for display in the format: "<URL> | <Title>".
+
+            For example:
+            
+            ```
+
+            ${Constants.WEBSITE_URL} | Webview Kiosk
+            
+            https://duckduckgo.com | DuckDuckGo
+            
+            https://f-droid.org | F-Droid
+
+            ```
         """.trimIndent(),
         placeholder = """
             e.g.
-            ${Constants.WEBSITE_URL}
-            ${Constants.SOURCE_CODE_URL}
+
+            ${Constants.WEBSITE_URL} | Webview Kiosk
+            
+            https://duckduckgo.com | DuckDuckGo
+            
+            https://f-droid.org | F-Droid
         """.trimIndent(),
         initialValue = userSettings.websiteBookmarks,
         settingKey = settingKey,
@@ -57,7 +76,6 @@ fun WebsiteBookmarksSetting() {
         validator = { input ->
             input.isEmpty() || input.lines().all { line ->
                 val trimmedLine = line.trim()
-
                 if (trimmedLine.count { it == '|' } > 1) {
                     false
                 } else {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/BookmarkDialog.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/components/webview/BookmarkDialog.kt
@@ -34,6 +34,11 @@ import uk.nktnet.webviewkiosk.config.UserSettings
 import uk.nktnet.webviewkiosk.utils.handleUserKeyEvent
 import uk.nktnet.webviewkiosk.utils.handleUserTouchEvent
 
+private data class Bookmark(
+    val url: String,
+    val title: String,
+)
+
 @Composable
 fun BookmarksDialog(
     showBookmarkDialog: Boolean,
@@ -46,7 +51,20 @@ fun BookmarksDialog(
 
     val context = LocalContext.current
     val userSettings = remember { UserSettings(context) }
-    val bookmarks = remember { userSettings.websiteBookmarks.lines().filter { it.isNotBlank() } }
+
+    val bookmarks = remember {
+        userSettings.websiteBookmarks.lines()
+            .filter { it.isNotBlank() }
+            .map { line ->
+                val parts = line.split("|", limit = 2)
+
+                Bookmark(
+                    url = parts[0].trim(),
+                    title = parts.getOrNull(1)?.trim().orEmpty(),
+                )
+            }
+    }
+
     val listState = rememberLazyListState()
 
     Dialog(onDismissRequest = onDismiss) {
@@ -64,7 +82,11 @@ fun BookmarksDialog(
                     .fillMaxSize()
                     .padding(16.dp)
             ) {
-                Text("Bookmarks", style = MaterialTheme.typography.headlineMedium)
+                Text(
+                    text = "Bookmarks",
+                    style = MaterialTheme.typography.headlineMedium
+                )
+
                 Spacer(Modifier.height(16.dp))
 
                 if (bookmarks.isEmpty()) {
@@ -85,13 +107,13 @@ fun BookmarksDialog(
                         modifier = Modifier.weight(1f),
                         state = listState
                     ) {
-                        itemsIndexed(bookmarks) { index, url ->
+                        itemsIndexed(bookmarks) { index, bookmark ->
                             Card(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(vertical = 4.dp)
                                     .clickable {
-                                        customLoadUrl(url)
+                                        customLoadUrl(bookmark.url)
                                         onDismiss()
                                     }
                             ) {
@@ -102,10 +124,23 @@ fun BookmarksDialog(
                                 ) {
                                     Text(
                                         text = buildAnnotatedString {
-                                            withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                            withStyle(
+                                                style = SpanStyle(
+                                                    fontWeight = FontWeight.Bold
+                                                )
+                                            ) {
                                                 append("[$index] ")
                                             }
-                                            append(url.toCharArray().joinToString("\u200B"))
+
+                                            val displayText = bookmark.title.ifEmpty {
+                                                bookmark.url
+                                            }
+
+                                            append(
+                                                displayText
+                                                    .toCharArray()
+                                                    .joinToString("\u200B")
+                                            )
                                         },
                                         maxLines = 2,
                                         overflow = TextOverflow.Ellipsis,
@@ -123,7 +158,9 @@ fun BookmarksDialog(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End
                 ) {
-                    TextButton(onClick = onDismiss) { Text("Close") }
+                    TextButton(onClick = onDismiss) {
+                        Text("Close")
+                    }
                 }
             }
         }

--- a/docs/content/docs/settings/web-content.mdx
+++ b/docs/content/docs/settings/web-content.mdx
@@ -52,9 +52,21 @@ Allow `https://allowsite.com` home page and all subdomains and paths for `https:
 
 ## 3. Bookmarks
 
-Specify bookmarked URLs one per line.
+Specify bookmarked URLs one per line. Blank lines will be ignored.
 
-This is accessible in the address bar. See also: "Allow Bookmark Access" under `Web Browsing`.
+This is accessible in the address bar. See the relevant setting `Web Browsing -> Allow Bookmark Access`.
+
+You can also specify a title for display in the format: `<URL> | <Title>`.
+
+For example:
+
+```log
+https://webviewkiosk.nktnet.uk | Webview Kiosk
+
+https://duckduckgo.com | DuckDuckGo
+
+https://f-droid.org | F-Droid
+```
 
 **Default:** (blank)
 


### PR DESCRIPTION
See #262.

Example:

> Settings -> Web Content -> Website Bookmarks

```
https://webviewkiosk.nktnet.uk | Webview Kiosk

https://youtube.com | YouTube

https://github.com | GitHub
```

Result:

<img width="370" alt="website-bookmark-result" src="https://github.com/user-attachments/assets/92adec50-f0b0-440a-b43b-03457de71183" />
