### PR TITLE
fix: issue #272 - remove NFC intent filter 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -126,10 +126,6 @@
                 <data android:mimeType="application/txt" />
             </intent-filter>
 
-            <intent-filter>
-                <action android:name="android.nfc.action.TAG_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -7,7 +7,6 @@ import android.content.IntentFilter
 import android.graphics.Color
 import android.net.Uri
 import android.nfc.NfcAdapter
-import android.nfc.Tag
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
@@ -173,7 +172,6 @@ class MainActivity : AppCompatActivity() {
         }
 
         if (intent != null) {
-            handleNfcIntent(intent)
             saveIntentUrl(intent)
         }
 
@@ -382,9 +380,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        if (handleNfcIntent(intent)) {
-            return
-        }
         if (!this::navController.isInitialized) {
             return
         }
@@ -495,35 +490,5 @@ class MainActivity : AppCompatActivity() {
         runCatching {
             adapter.disableReaderMode(this)
         }
-    }
-
-    private fun handleNfcIntent(intent: Intent): Boolean {
-        if (!this::userSettings.isInitialized || !userSettings.allowNfc) {
-            return false
-        }
-
-        val action = intent.action ?: return false
-        @Suppress("DEPRECATION")
-        if (
-            action != NfcAdapter.ACTION_TAG_DISCOVERED
-            && action != NfcAdapter.ACTION_TECH_DISCOVERED
-            && action != NfcAdapter.ACTION_NDEF_DISCOVERED
-        ) {
-            return false
-        }
-
-        val tag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
-        }
-
-        tag?.let {
-            NfcBridgeManager.onTagScanned(it, action)
-            return true
-        }
-
-        return false
     }
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/NfcBridgeManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/NfcBridgeManager.kt
@@ -52,7 +52,7 @@ object NfcBridgeManager {
         return requestId
     }
 
-    fun onTagScanned(tag: Tag, action: String? = null) {
+    fun onTagScanned(tag: Tag) {
         val webView = webViewRef?.get() ?: return
 
         val writeResult = consumePendingWriteAndWrite(tag)
@@ -69,7 +69,7 @@ object NfcBridgeManager {
             return
         }
 
-        val payload = buildTagPayload(tag, action)
+        val payload = buildTagPayload(tag)
         webView.post {
             webView.evaluateJavascript(
                 "window.__WebviewKioskNfcBridge && window.__WebviewKioskNfcBridge.onTagScanned($payload);",
@@ -252,9 +252,8 @@ object NfcBridgeManager {
         return byteArrayOf()
     }
 
-    private fun buildTagPayload(tag: Tag, action: String?): JSONObject {
+    private fun buildTagPayload(tag: Tag): JSONObject {
         val obj = JSONObject()
-        obj.put("action", action ?: "")
         obj.put("serialNumber", toHex(tag.id ?: byteArrayOf()))
         obj.put("timestamp", System.currentTimeMillis())
 


### PR DESCRIPTION
Resolves #272.

The NFC intent filter is set (for 'TAG_DISCOVERED') causing the Webview Kiosk app to open when a tag is scanned and another app is not prioritized for that tag type. The NFC intent is not needed to read NFC tags while the app is in the foreground and can be removed.