### PR TITLE
fix: out-of-memory error when downloading large blobs

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handleDownloadPrompt.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handleDownloadPrompt.kt
@@ -172,32 +172,132 @@ fun downloadNormal(
     dm.enqueue(request)
 }
 
-// https://proandroiddev.com/blob-downloads-not-working-in-android-web-view-heres-the-real-fix-243144a2a426
-private fun fetchBlob(webView: WebView, blobUrl: String, mimeType: String?,  filename: String) {
+private fun fetchBlob(
+    webView: WebView,
+    blobUrl: String,
+    mimeType: String?,
+    filename: String
+) {
+    val transferId = java.util.UUID.randomUUID().toString()
+
+    val quotedBlobUrl = JSONObject.quote(blobUrl)
+    val quotedMimeType = JSONObject.quote(mimeType ?: "application/octet-stream")
+    val quotedFilename = JSONObject.quote(filename)
+    val quotedTransferId = JSONObject.quote(transferId)
+
     val js = """
         (async function() {
-            try {
-                const blobUrl = ${JSONObject.quote(blobUrl)};
-                const response = await fetch(blobUrl);
-                const blob = await response.blob();
-                const reader = new FileReader();
-                reader.onloadend = function() {
-                    ${BlobInterface.NAME}.download(reader.result, '$mimeType', '$filename');
-                };
-                reader.readAsDataURL(blob);
-                return;
-            } catch(e) {}
+            const bridge = ${BlobInterface.NAME};
+            const blobUrl = $quotedBlobUrl;
+            const mimeType = $quotedMimeType;
+            const filename = $quotedFilename;
+            const transferId = $quotedTransferId;
 
-            if (window.__${Constants.APP_SCHEME}_lastBlob) {
-                const reader2 = new FileReader();
-                reader2.onloadend = function() {
-                    ${BlobInterface.NAME}.download(reader2.result, '$mimeType', '$filename');
-                };
-                reader2.readAsDataURL(window.__${Constants.APP_SCHEME}_lastBlob);
-                return;
+            // Keep each bridge call comfortably small.
+            const CHUNK_SIZE = 256 * 1024;
+
+            function readChunkAsBase64(blob) {
+                return new Promise(function(resolve, reject) {
+                    const reader = new FileReader();
+
+                    reader.onload = function() {
+                        try {
+                            const result = reader.result;
+
+                            if (typeof result !== 'string') {
+                                reject(new Error('Unexpected FileReader result'));
+                                return;
+                            }
+
+                            const comma = result.indexOf(',');
+                            resolve(comma >= 0 ? result.substring(comma + 1) : result);
+                        } catch (e) {
+                            reject(e);
+                        }
+                    };
+
+                    reader.onerror = function() {
+                        reject(reader.error || new Error('FileReader failed'));
+                    };
+
+                    reader.readAsDataURL(blob);
+                });
             }
 
-            ${BlobInterface.NAME}.error('Blob fetch failed');
+            try {
+                let blob = null;
+
+                try {
+                    const response = await fetch(blobUrl);
+
+                    if (!response.ok) {
+                        throw new Error(
+                            'Blob fetch returned HTTP ' + response.status
+                        );
+                    }
+
+                    blob = await response.blob();
+                } catch (e) {
+                    blob = window.__${Constants.APP_SCHEME}_lastBlob || null;
+                }
+
+                if (!blob) {
+                    throw new Error('Blob fetch failed');
+                }
+
+                if (!bridge.startDownload(
+                    transferId,
+                    mimeType,
+                    filename
+                )) {
+                    throw new Error('Unable to create download file');
+                }
+
+                for (
+                    let offset = 0;
+                    offset < blob.size;
+                    offset += CHUNK_SIZE
+                ) {
+                    const end = Math.min(
+                        offset + CHUNK_SIZE,
+                        blob.size
+                    );
+
+                    const chunk = blob.slice(offset, end);
+
+                    const base64Chunk =
+                        await readChunkAsBase64(chunk);
+
+                    if (!bridge.appendChunk(
+                        transferId,
+                        base64Chunk
+                    )) {
+                        throw new Error(
+                            'Failed writing download chunk'
+                        );
+                    }
+                }
+
+                if (!bridge.finishDownload(transferId)) {
+                    throw new Error(
+                        'Failed finalising download'
+                    );
+                }
+
+                // Your hook keeps a strong reference to the most recently
+                // created blob. Release it after the file has been written.
+                window.__${Constants.APP_SCHEME}_lastBlob = null;
+
+            } catch (e) {
+                try {
+                    bridge.abortDownload(transferId);
+                } catch (_) {}
+
+                bridge.error(
+                    'Blob download failed: ' +
+                    (e && e.message ? e.message : String(e))
+                );
+            }
         })();
     """.trimIndent()
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
@@ -10,9 +10,11 @@ import uk.nktnet.webviewkiosk.managers.CustomNotificationManager
 import uk.nktnet.webviewkiosk.managers.ToastManager
 import java.io.File
 import java.io.FileOutputStream
+import java.util.concurrent.ConcurrentHashMap
 
-// https://proandroiddev.com/blob-downloads-not-working-in-android-web-view-heres-the-real-fix-243144a2a426
-class BlobInterface(private val context: Context) {
+class BlobInterface(
+    private val context: Context
+) {
     companion object {
         const val NAME = "WebviewKioskBlobInterface"
 
@@ -30,9 +32,11 @@ class BlobInterface(private val context: Context) {
                 if (window.__${Constants.APP_SCHEME}_blobHookInstalled) {
                     return;
                 }
+
                 window.__${Constants.APP_SCHEME}_blobHookInstalled = true;
 
                 const orig = URL.createObjectURL;
+
                 URL.createObjectURL = function(blob) {
                     window.__${Constants.APP_SCHEME}_lastBlob = blob;
                     return orig.call(URL, blob);
@@ -41,50 +45,201 @@ class BlobInterface(private val context: Context) {
         """
     }
 
-    @JavascriptInterface
-    fun error(message: String?) {
-        ToastManager.show(context, message ?: "Unknown error")
-    }
+    private data class ActiveDownload(
+        val file: File,
+        val output: FileOutputStream,
+        val mimeType: String?
+    )
+
+    private val activeDownloads =
+        ConcurrentHashMap<String, ActiveDownload>()
 
     @JavascriptInterface
-    fun download(base64: String?, mimeType: String?, filename: String) {
-        if (!isActive || base64 == null) {
-            return
+    fun error(message: String?) {
+        ToastManager.show(
+            context,
+            message ?: "Unknown error"
+        )
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun startDownload(
+        transferId: String,
+        mimeType: String?,
+        filename: String
+    ): Boolean {
+        if (!isActive) {
+            return false
+        }
+
+        if (!isValidFilename(filename)) {
+            ToastManager.show(
+                context,
+                "Invalid filename: '$filename'"
+            )
+            return false
+        }
+
+        return try {
+            // Clean up an accidentally reused transfer ID.
+            activeDownloads.remove(transferId)?.let {
+                try {
+                    it.output.close()
+                } catch (_: Exception) {
+                }
+            }
+
+            val downloads =
+                Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_DOWNLOADS
+                )
+
+            if (!downloads.exists()) {
+                downloads.mkdirs()
+            }
+
+            val file = File(downloads, filename)
+            val output = FileOutputStream(file)
+
+            activeDownloads[transferId] = ActiveDownload(
+                file = file,
+                output = output,
+                mimeType = mimeType
+            )
+
+            true
+        } catch (e: Exception) {
+            ToastManager.show(
+                context,
+                "Unable to start download: ${e.message}"
+            )
+            false
+        }
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun appendChunk(
+        transferId: String,
+        base64Chunk: String?
+    ): Boolean {
+        if (!isActive || base64Chunk == null) {
+            return false
+        }
+
+        val download =
+            activeDownloads[transferId]
+                ?: return false
+
+        return try {
+            /*
+             * Only this one small chunk is decoded into memory.
+             *
+             * NO_WRAP is suitable here because FileReader's Base64 output
+             * contains no line wrapping.
+             */
+            val bytes = Base64.decode(
+                base64Chunk,
+                Base64.NO_WRAP
+            )
+
+            synchronized(download) {
+                download.output.write(bytes)
+            }
+
+            true
+        } catch (e: Exception) {
+            abortInternal(transferId)
+
+            ToastManager.show(
+                context,
+                "Download failed: ${e.message}"
+            )
+
+            false
+        }
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun finishDownload(
+        transferId: String
+    ): Boolean {
+        val download =
+            activeDownloads.remove(transferId)
+                ?: return false
+
+        return try {
+            synchronized(download) {
+                download.output.flush()
+                download.output.close()
+            }
+
+            ToastManager.show(
+                context,
+                "${download.file.name} downloaded"
+            )
+
+            val userSettings = UserSettings(context)
+
+            if (userSettings.allowNotifications) {
+                CustomNotificationManager
+                    .sendBlobDownloadNotification(
+                        context,
+                        download.file
+                    )
+            }
+
+            true
+        } catch (e: Exception) {
+            try {
+                download.output.close()
+            } catch (_: Exception) {
+            }
+
+            ToastManager.show(
+                context,
+                "Failed to finish download: ${e.message}"
+            )
+
+            false
+        }
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun abortDownload(
+        transferId: String
+    ) {
+        abortInternal(transferId)
+    }
+
+    private fun abortInternal(
+        transferId: String
+    ) {
+        val download =
+            activeDownloads.remove(transferId)
+                ?: return
+
+        try {
+            download.output.close()
+        } catch (_: Exception) {
         }
 
         try {
-            val cleanBase64 = base64.substringAfter(',')
-            val bytes = Base64.decode(cleanBase64, Base64.DEFAULT)
-            saveFile(filename, bytes)
-        } catch (e: Exception) {
-            ToastManager.show(context, "Failed (mimeType=${mimeType}: ${e.message}")
+            download.file.delete()
+        } catch (_: Exception) {
         }
     }
 
-    private fun saveFile(filename: String, bytes: ByteArray) {
-        if (
-            filename.contains("..")
-            || filename.contains("/")
-            || filename.contains("\\")
-        ) {
-            ToastManager.show(
-                context,
-                "Invalid filename: '$filename' (contains '..', '/' or '\\'"
-            )
-            return
-        }
-        val downloads = Environment.getExternalStoragePublicDirectory(
-            Environment.DIRECTORY_DOWNLOADS
-        )
-        val file = File(downloads, filename)
-        FileOutputStream(file).use {
-            it.write(bytes)
-        }
-        ToastManager.show(context, "$filename downloaded")
-
-        val userSettings = UserSettings(context)
-        if (userSettings.allowNotifications) {
-            CustomNotificationManager.sendBlobDownloadNotification(context, file)
-        }
+    private fun isValidFilename(
+        filename: String
+    ): Boolean {
+        return filename.isNotBlank()
+                && !filename.contains("..")
+                && !filename.contains("/")
+                && !filename.contains("\\")
+                && !filename.contains('\u0000')
     }
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
@@ -3,6 +3,7 @@ package uk.nktnet.webviewkiosk.utils.webview.interfaces
 import android.content.Context
 import android.os.Environment
 import android.util.Base64
+import android.util.Log
 import android.webkit.JavascriptInterface
 import uk.nktnet.webviewkiosk.config.Constants
 import uk.nktnet.webviewkiosk.config.UserSettings
@@ -133,12 +134,6 @@ class BlobInterface(
                 ?: return false
 
         return try {
-            /*
-             * Only this one small chunk is decoded into memory.
-             *
-             * NO_WRAP is suitable here because FileReader's Base64 output
-             * contains no line wrapping.
-             */
             val bytes = Base64.decode(
                 base64Chunk,
                 Base64.NO_WRAP
@@ -195,7 +190,8 @@ class BlobInterface(
         } catch (e: Exception) {
             try {
                 download.output.close()
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e(javaClass.simpleName, "Failed to close download output", e)
             }
 
             ToastManager.show(
@@ -224,22 +220,30 @@ class BlobInterface(
 
         try {
             download.output.close()
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.e(
+                javaClass.simpleName,
+                "Failed to close download output during abort",
+                e
+            )
         }
 
         try {
             download.file.delete()
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.e(javaClass.simpleName, "Failed to delete file during abort", e)
         }
     }
 
     private fun isValidFilename(
         filename: String
     ): Boolean {
-        return filename.isNotBlank()
+        return (
+            filename.isNotBlank()
                 && !filename.contains("..")
                 && !filename.contains("/")
                 && !filename.contains("\\")
                 && !filename.contains('\u0000')
+        )
     }
 }


### PR DESCRIPTION
Resolves the following (from Google Play Console):

```
Exception java.lang.OutOfMemoryError:
  at java.lang.StringFactory.newStringFromBytes
  at java.lang.StringLatin1.newString (StringLatin1.java:774)
  at java.lang.StringBuilder.toString (StringBuilder.java:500)
  at uk.nktnet.webviewkiosk.utils.webview.handlers.HandleDownloadPromptKt.handleDownloadPrompt$lambda$10 (HandleDownloadPrompt.kt:137)
  at android.view.View.performClick (View.java:7540)
  at android.view.View.performClickInternal (View.java:7513)
  at android.view.View.-$$Nest$mperformClickInternal (View.java)
  at android.view.View$PerformClick.run (View.java:29583)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:204)
  at android.os.Looper.loop (Looper.java:291)
  at android.app.ActivityThread.main (ActivityThread.java:8155)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:601)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1136)
```