### PR TITLE
fix(nfc): switch to foreground dispatch to avoid android.os.DeadObjectException crash

### DIFF
--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -420,7 +420,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        disableNfcForegroundDispatch()
         unregisterReceiver(broadcastReceiver)
         if (
             userSettings.mqttUseForegroundService
@@ -537,7 +536,9 @@ class MainActivity : AppCompatActivity() {
 
         tag ?: return false
 
-        NfcBridgeManager.onTagScanned(tag)
+        lifecycleScope.launch(Dispatchers.IO) {
+            NfcBridgeManager.onTagScanned(tag)
+        }
         return true
     }
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -1,5 +1,6 @@
 package uk.nktnet.webviewkiosk
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -7,6 +8,7 @@ import android.content.IntentFilter
 import android.graphics.Color
 import android.net.Uri
 import android.nfc.NfcAdapter
+import android.nfc.Tag
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
@@ -82,12 +84,6 @@ class MainActivity : AppCompatActivity() {
     private var nfcAdapter: NfcAdapter? = null
 
     private var lastOnStartTime = 0L
-
-    private val nfcReaderCallback = NfcAdapter.ReaderCallback { tag ->
-        if (this::userSettings.isInitialized && userSettings.allowNfc) {
-            NfcBridgeManager.onTagScanned(tag)
-        }
-    }
 
     val broadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -349,11 +345,11 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         backButtonService.onBackPressedCallback.isEnabled = true
-        enableNfcReaderMode()
+        enableNfcForegroundDispatch()
     }
 
     override fun onPause() {
-        disableNfcReaderMode()
+        disableNfcForegroundDispatch()
         super.onPause()
     }
 
@@ -380,6 +376,11 @@ class MainActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+
+        if (handleNfcIntent(intent)) {
+            return
+        }
+
         if (!this::navController.isInitialized) {
             return
         }
@@ -419,7 +420,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        disableNfcReaderMode()
+        disableNfcForegroundDispatch()
         unregisterReceiver(broadcastReceiver)
         if (
             userSettings.mqttUseForegroundService
@@ -466,29 +467,76 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-    private fun enableNfcReaderMode() {
+    private fun enableNfcForegroundDispatch() {
         if (!this::userSettings.isInitialized || !userSettings.allowNfc) {
             return
         }
 
         val adapter = nfcAdapter ?: return
-        val flags = (
-            NfcAdapter.FLAG_READER_NFC_A
-                or NfcAdapter.FLAG_READER_NFC_B
-                or NfcAdapter.FLAG_READER_NFC_F
-                or NfcAdapter.FLAG_READER_NFC_V
-                or NfcAdapter.FLAG_READER_NFC_BARCODE
+
+        val intent = Intent(this, javaClass).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
+
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_MUTABLE
+            } else {
+                0
+            }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            flags
         )
 
         runCatching {
-            adapter.enableReaderMode(this, nfcReaderCallback, flags, null)
+            adapter.enableForegroundDispatch(
+                this,
+                pendingIntent,
+                null,
+                null
+            )
         }
     }
 
-    private fun disableNfcReaderMode() {
+    private fun disableNfcForegroundDispatch() {
         val adapter = nfcAdapter ?: return
+
         runCatching {
-            adapter.disableReaderMode(this)
+            adapter.disableForegroundDispatch(this)
         }
+    }
+
+    private fun handleNfcIntent(intent: Intent): Boolean {
+        if (!this::userSettings.isInitialized || !userSettings.allowNfc) {
+            return false
+        }
+
+        @Suppress("DEPRECATION")
+        if (
+            intent.action != NfcAdapter.ACTION_TAG_DISCOVERED &&
+            intent.action != NfcAdapter.ACTION_TECH_DISCOVERED &&
+            intent.action != NfcAdapter.ACTION_NDEF_DISCOVERED
+        ) {
+            return false
+        }
+
+        val tag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(
+                NfcAdapter.EXTRA_TAG,
+                Tag::class.java
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+        }
+
+        tag ?: return false
+
+        NfcBridgeManager.onTagScanned(tag)
+        return true
     }
 }


### PR DESCRIPTION
Fixes an NFC crash that could happen when the app resumes and the Android NFC service has died or restarted.

This replaces NFC Reader Mode with Foreground Dispatch, so tags are now handled through `onNewIntent()` and passed to the existing `NfcBridgeManager`.

---

Google Play Console Crash Details:

- Samsung Galaxy S25 Ultra
- Android 16 (SDK 36)
- Version: 132 (0.26.18)
- Occurred: 11 days ago (Thursday, 27 August 2026)

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:6632)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:6705)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:73)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:63)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:169)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:101)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3287)
  at android.os.Handler.dispatchMessage (Handler.java:132)
  at android.os.Looper.dispatchMessage (Looper.java:358)
  at android.os.Looper.loopOnce (Looper.java:288)
  at android.os.Looper.loop (Looper.java:392)
  at android.app.ActivityThread.main (ActivityThread.java:10346)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:638)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:972)
Caused by java.lang.RuntimeException: android.os.DeadObjectException
  at android.nfc.NfcAdapter.attemptDeadServiceRecovery (NfcAdapter.java:1024)
  at android.nfc.NfcAdapter.callService (NfcAdapter.java:2661)
  at android.nfc.NfcActivityManager.requestNfcServiceCallback (NfcActivityManager.java:197)
  at android.nfc.NfcActivityManager.onActivityResumed (NfcActivityManager.java:255)
  at android.app.Application.dispatchActivityResumed (Application.java:465)
  at android.app.Activity.dispatchActivityResumed (Activity.java:1690)
  at android.app.Activity.onResume (Activity.java:2394)
  at androidx.fragment.app.FragmentActivity.onResume (FragmentActivity.java:310)
  at uk.nktnet.webviewkiosk.MainActivity.onResume (MainActivity.kt:352)
  at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1740)
  at android.app.Activity.performResume (Activity.java:9930)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:6602)
Caused by android.os.DeadObjectException:
  at android.os.BinderProxy.transactNative
  at android.os.BinderProxy.transact (BinderProxy.java:670)
  at android.nfc.INfcAdapter$Stub$Proxy.setAppCallback (INfcAdapter.java:1445)
  at android.nfc.NfcActivityManager.lambda$requestNfcServiceCallback$1 (NfcActivityManager.java:197)
  at android.nfc.NfcActivityManager.$r8$lambda$KflxZSFsTDQRU5SoTsvUbpATMJ4 (NfcActivityManager.java)
  at android.nfc.NfcActivityManager$$ExternalSyntheticLambda0.call (D8$$SyntheticClass)
  at android.nfc.NfcAdapter.callService (NfcAdapter.java:2659)
```

---

@avt613 are you able to help test that this PR still works for your use case?
