### PR TITLE
fix: harden downloads, PDF handling and lifecycle cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,10 +106,11 @@
                 <data android:mimeType="image/*" />
                 <data android:mimeType="audio/*" />
                 <data android:mimeType="video/*" />
-                <data android:mimeType="application/json" />
                 <data android:mimeType="application/javascript" />
-                <data android:mimeType="application/xml" />
+                <data android:mimeType="application/json" />
+                <data android:mimeType="application/pdf" />
                 <data android:mimeType="application/txt" />
+                <data android:mimeType="application/xml" />
                 <data android:scheme="content" />
             </intent-filter>
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/MainActivity.kt
@@ -432,6 +432,7 @@ class MainActivity : AppCompatActivity() {
         stopService(
             Intent(this, MqttForegroundService::class.java)
         )
+        AuthenticationManager.clear(this)
         super.onDestroy()
     }
 

--- a/app/src/main/java/uk/nktnet/webviewkiosk/config/data/WebviewCreation.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/config/data/WebviewCreation.kt
@@ -3,6 +3,10 @@ package uk.nktnet.webviewkiosk.config.data
 import android.webkit.WebView
 
 sealed class WebViewCreation {
-    data class Success(val webView: WebView) : WebViewCreation()
+    data class Success(
+        val webView: WebView,
+        val onDispose: () -> Unit = {}
+    ) : WebViewCreation()
+
     data class Failure(val error: Exception) : WebViewCreation()
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/AuthenticationManager.kt
@@ -52,6 +52,12 @@ object AuthenticationManager {
         this.activity = activity
     }
 
+    fun clear(activity: AppCompatActivity) {
+        if (this.activity === activity) {
+            this.activity = null
+        }
+    }
+
     fun checkAuthAndRefreshSession(): Boolean {
         val now = System.currentTimeMillis()
         val isValid = (

--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/PdfJsManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/PdfJsManager.kt
@@ -8,21 +8,55 @@ import uk.nktnet.webviewkiosk.config.Constants
 import uk.nktnet.webviewkiosk.config.Constants.PDF_JS_ASSETS_DIR
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.net.URL
 
 object PdfJsManager {
+    private const val PDF_JS_VERSION = "6.3.289"
+    private const val VERSION_FILE = ".version"
+
     private val assetUrls = mapOf(
-        "https://cdn.jsdelivr.net/npm/pdfjs-dist/legacy/build/pdf.mjs" to "pdf.mjs",
-        "https://cdn.jsdelivr.net/npm/pdfjs-dist/legacy/build/pdf.worker.mjs" to "pdf.worker.mjs"
+        "https://cdn.jsdelivr.net/npm/pdfjs-dist@$PDF_JS_VERSION/legacy/build/pdf.mjs" to "pdf.mjs",
+        "https://cdn.jsdelivr.net/npm/pdfjs-dist@$PDF_JS_VERSION/legacy/build/pdf.worker.mjs" to "pdf.worker.mjs"
     )
 
     private fun getTargetDirectory(context: Context): File {
         return File(context.filesDir, PDF_JS_ASSETS_DIR)
     }
 
+    private fun isCurrentVersion(targetDir: File): Boolean {
+        return runCatching {
+            File(targetDir, VERSION_FILE).readText().trim() == PDF_JS_VERSION
+        }.getOrDefault(false)
+    }
+
+    private fun downloadAsset(url: String, outputFile: File) {
+        val tempFile = File(outputFile.parentFile, "${outputFile.name}.part")
+        tempFile.delete()
+
+        try {
+            URL(url).openStream().use { input ->
+                FileOutputStream(tempFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+
+            if (!tempFile.renameTo(outputFile)) {
+                throw IOException("Failed to finalise ${outputFile.name}")
+            }
+        } finally {
+            tempFile.delete()
+        }
+    }
+
     suspend fun downloadAssets(context: Context): Boolean = withContext(Dispatchers.IO) {
         try {
             val targetDir = getTargetDirectory(context)
+
+            if (!isCurrentVersion(targetDir)) {
+                targetDir.deleteRecursively()
+            }
+
             if (!targetDir.exists()) {
                 targetDir.mkdirs()
             }
@@ -30,20 +64,12 @@ object PdfJsManager {
             for ((url, fileName) in assetUrls) {
                 val outputFile = File(targetDir, fileName)
 
-                outputFile.parentFile?.let { parent ->
-                    if (!parent.exists()) {
-                        parent.mkdirs()
-                    }
-                }
-
                 if (!outputFile.exists()) {
-                    URL(url).openStream().use { input ->
-                        FileOutputStream(outputFile).use { output ->
-                            input.copyTo(output)
-                        }
-                    }
+                    downloadAsset(url, outputFile)
                 }
             }
+
+            File(targetDir, VERSION_FILE).writeText(PDF_JS_VERSION)
             ToastManager.show(context, "Download complete")
             true
         } catch (e: Exception) {
@@ -55,9 +81,13 @@ object PdfJsManager {
 
     fun areAssetsReady(context: Context): Boolean {
         val targetDir = getTargetDirectory(context)
-        return targetDir.exists() && assetUrls.values.all {
-            File(targetDir, it).exists()
-        }
+        return (
+            targetDir.exists()
+                && isCurrentVersion(targetDir)
+                && assetUrls.values.all {
+                    File(targetDir, it).isFile
+                }
+        )
     }
 
     fun clearAssets(context: Context) {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/managers/UnifiedPushManager.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/managers/UnifiedPushManager.kt
@@ -120,7 +120,7 @@ object UnifiedPushManager {
                 """
                 instance=$instance
                 messageForDistributor=${userSettings.unifiedPushMessageForDistributor}
-                error: distributor is not installed (${userSettings.unifiedPushDistributor})
+                error: invalid VAPID public key
                 """.trimIndent()
             )
             ToastManager.show(context, "Error: invalid VAPID public key")

--- a/app/src/main/java/uk/nktnet/webviewkiosk/services/MqttForegroundService.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/services/MqttForegroundService.kt
@@ -112,11 +112,10 @@ class MqttForegroundService : Service() {
             pollLockTaskModeJob = scope.launch {
                 while (isServiceActive) {
                     val status = MqttManager.getState()
-                    if (lastStatus != null && status == lastStatus) {
-                        continue
+                    if (lastStatus == null || status != lastStatus) {
+                        lastStatus = status
+                        updateNotification(status)
                     }
-                    lastStatus = status
-                    updateNotification(status)
                     delay(1000.milliseconds)
                 }
             }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/ui/screens/WebviewScreen.kt
@@ -1,10 +1,6 @@
 package uk.nktnet.webviewkiosk.ui.screens
 
-import android.app.Activity
-import android.content.Context
 import android.os.Build
-import android.util.Base64
-import android.util.Log
 import android.webkit.CookieManager
 import android.webkit.HttpAuthHandler
 import android.webkit.URLUtil.isValidUrl
@@ -110,7 +106,6 @@ import uk.nktnet.webviewkiosk.utils.webview.isCustomBlockPageUrl
 import uk.nktnet.webviewkiosk.utils.webview.loadBlockedPage
 import uk.nktnet.webviewkiosk.utils.webview.resolveUrlOrSearch
 import java.io.File
-import java.net.URL
 import kotlin.time.Duration.Companion.milliseconds
 
 fun Modifier.imePaddingCompat(): Modifier = if (
@@ -307,6 +302,7 @@ fun WebviewScreen(navController: NavController) {
 
     DisposableEffect(webView) {
         onDispose {
+            (webViewCreation as? WebViewCreation.Success)?.onDispose?.invoke()
             NfcBridgeManager.detachWebView(webView)
             webView.stopLoading()
             webView.removeAllViews()
@@ -342,18 +338,23 @@ fun WebviewScreen(navController: NavController) {
         } else if (schemeType == SchemeType.FILE) {
             val mimeType = getMimeType(context, uri)
             val file = File(uri.path ?: "")
+            val isPdf = (
+                mimeType == "application/pdf"
+                    || file.extension.lowercase() == "pdf"
+            )
+
+            if (
+                file.exists()
+                && isPdf
+                && userSettings.supportPdfRendering
+                && PdfJsManager.areAssetsReady(context)
+            ) {
+                handlePdfUrlRendering(webView, newUrl)
+                return
+            }
+
             val pageContent = when {
                 !file.exists() -> generateFileMissingPage(file, userSettings.theme)
-                (
-                    userSettings.supportPdfRendering
-                        && PdfJsManager.areAssetsReady(context)
-                        && (
-                            mimeType == "application/pdf"
-                            || file.extension.lowercase() == "pdf"
-                        )
-                ) -> {
-                    generatePdfRendererHtml(newUrl)
-                }
                 !isSupportedFileURLMimeType(mimeType) -> generateUnsupportedMimeTypePage(
                     context, file, mimeType, userSettings.theme
                 )
@@ -388,8 +389,7 @@ fun WebviewScreen(navController: NavController) {
                 newUrl
             }
             if (targetPdfUrl.isNotEmpty()) {
-                handlePdfRemoteUrlRendering(
-                    context,
+                handlePdfUrlRendering(
                     webView,
                     targetPdfUrl,
                 )
@@ -714,8 +714,7 @@ fun WebviewScreen(navController: NavController) {
     )
 }
 
-private fun handlePdfRemoteUrlRendering(
-    context: Context,
+private fun handlePdfUrlRendering(
     webView: WebView,
     targetPdfUrl: String
 ) {
@@ -723,29 +722,16 @@ private fun handlePdfRemoteUrlRendering(
         return
     }
 
-    Thread {
-        try {
-            ToastManager.show(context, "Preparing to render PDF...")
-            val bytes = URL(targetPdfUrl).openStream().use { it.readBytes() }
-            val base64Data = Base64.encodeToString(bytes, Base64.NO_WRAP)
-            val activity = context as? Activity ?: return@Thread
-            ToastManager.cancel()
-            activity.runOnUiThread {
-                val htmlContent = generatePdfRendererHtml(base64Data)
-                val encodedPdfUrl = java.net.URLEncoder.encode(targetPdfUrl, "UTF-8")
-                val baseUrlWithFallback = "${Constants.PDF_JS_ASSETS_DUMMY_URL}?wk_pdf_url=$encodedPdfUrl"
+    val htmlContent = generatePdfRendererHtml(targetPdfUrl)
+    val encodedPdfUrl = java.net.URLEncoder.encode(targetPdfUrl, "UTF-8")
+    val baseUrlWithFallback =
+        "${Constants.PDF_JS_ASSETS_DUMMY_URL}?wk_pdf_url=$encodedPdfUrl"
 
-                webView.loadDataWithBaseURL(
-                    baseUrlWithFallback,
-                    htmlContent,
-                    "text/html",
-                    "UTF-8",
-                    null
-                )
-            }
-        } catch (e: Exception) {
-            Log.e(Constants.APP_SCHEME, "Failed to fetch PDF: $targetPdfUrl", e)
-            ToastManager.show(context, "PDF fetch failed: ${e.message}")
-        }
-    }.start()
+    webView.loadDataWithBaseURL(
+        baseUrlWithFallback,
+        htmlContent,
+        "text/html",
+        "UTF-8",
+        null
+    )
 }

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/createCustomWebview.kt
@@ -54,6 +54,7 @@ import uk.nktnet.webviewkiosk.utils.webview.SchemeType
 import uk.nktnet.webviewkiosk.utils.webview.getBlockInfo
 import uk.nktnet.webviewkiosk.utils.webview.handlers.handleDownloadPrompt
 import uk.nktnet.webviewkiosk.utils.webview.handlers.handleGeolocationRequest
+import uk.nktnet.webviewkiosk.utils.webview.handlers.handlePdfSourceRequest
 import uk.nktnet.webviewkiosk.utils.webview.handlers.handlePermissionRequest
 import uk.nktnet.webviewkiosk.utils.webview.handlers.handleSslErrorPromptRequest
 import uk.nktnet.webviewkiosk.utils.webview.interfaces.BatteryInterface
@@ -172,8 +173,16 @@ fun createCustomWebview(
         return false
     }
 
+    val blobInterfaces = remember { mutableSetOf<BlobInterface>() }
+
     fun buildWebView(): WebView {
-        return WebView(context).apply {
+        val blobInterface = if (userSettings.allowFileDownload) {
+            BlobInterface(context).also { blobInterfaces.add(it) }
+        } else {
+            null
+        }
+
+        val webView = WebView(context).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT
@@ -246,9 +255,11 @@ fun createCustomWebview(
                     }
                 }
             }
-            if (userSettings.allowFileDownload) {
-                addJavascriptInterface(BlobInterface(context), BlobInterface.NAME)
+            blobInterface?.let {
+                addJavascriptInterface(it, BlobInterface.NAME)
             }
+
+            val requestUserAgent = settings.userAgentString
 
             webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
@@ -331,10 +342,20 @@ fun createCustomWebview(
                     view: WebView?,
                     request: WebResourceRequest?
                 ): WebResourceResponse? {
-                    if (assetLoader != null && request != null) {
-                        val response = assetLoader.shouldInterceptRequest(request.url)
-                        if (response != null) {
-                            return response
+                    if (request != null) {
+                        handlePdfSourceRequest(
+                            request,
+                            requestUserAgent,
+                            userSettings.allowLocalFiles
+                        )?.let {
+                            return it
+                        }
+
+                        if (assetLoader != null) {
+                            val response = assetLoader.shouldInterceptRequest(request.url)
+                            if (response != null) {
+                                return response
+                            }
                         }
                     }
                     return super.shouldInterceptRequest(view, request)
@@ -517,6 +538,10 @@ fun createCustomWebview(
                         "WebView renderer gone. crashed=${detail.didCrash()}"
                     )
                     parent?.removeView(view)
+                    blobInterface?.let {
+                        it.dispose()
+                        blobInterfaces.remove(it)
+                    }
                     view.destroy()
                     if (parent != null) {
                         val newWebView = buildWebView()
@@ -720,12 +745,17 @@ fun createCustomWebview(
                 )
             }
         }
+
+        return webView
     }
 
     val webViewCreationResult = remember {
         try {
             val webView = buildWebView()
-            WebViewCreation.Success(webView)
+            WebViewCreation.Success(webView) {
+                blobInterfaces.toList().forEach { it.dispose() }
+                blobInterfaces.clear()
+            }
         } catch (e: Exception) {
             Log.e(Constants.APP_SCHEME, "Failed to create WebView", e)
             WebViewCreation.Failure(e)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/fileUtils.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/fileUtils.kt
@@ -22,10 +22,11 @@ val supportedMimeTypesArray = arrayOf(
     "image/*",
     "audio/*",
     "video/*",
-    "application/json",
     "application/javascript",
+    "application/json",
+    "application/pdf",
+    "application/txt",
     "application/xml",
-    "application/txt"
 )
 
 fun listLocalFiles(dir: File): List<File> {
@@ -34,7 +35,13 @@ fun listLocalFiles(dir: File): List<File> {
 
 fun getFileNameFromUri(context: Context, uri: Uri): String {
     var name: String? = null
-    val cursor: Cursor? = context.contentResolver.query(uri, null, null, null, null)
+    val cursor: Cursor? = context.contentResolver.query(
+        uri,
+        null,
+        null,
+        null,
+        null,
+    )
     cursor?.use {
         if (it.moveToFirst()) {
             val index = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handleDownloadPrompt.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handleDownloadPrompt.kt
@@ -9,6 +9,7 @@ import android.os.Environment
 import android.util.Log
 import android.view.Gravity
 import android.view.ViewGroup.LayoutParams
+import android.webkit.CookieManager
 import android.webkit.MimeTypeMap
 import android.webkit.URLUtil
 import android.webkit.WebView
@@ -99,6 +100,9 @@ fun handleDownloadPrompt(
     val dialog = AlertDialog.Builder(context)
         .setView(layout)
         .setOnCancelListener {
+            if (uri.scheme == "blob") {
+                releaseCapturedBlob(webView, url)
+            }
             UserInteractionStateSingleton.onUserInteraction()
         }
         .setOnDismissListener {
@@ -108,6 +112,9 @@ fun handleDownloadPrompt(
 
     val cancelButton = Button(context).apply { text = "Cancel" }
     cancelButton.setOnClickListener {
+        if (uri.scheme == "blob") {
+            releaseCapturedBlob(webView, url)
+        }
         UserInteractionStateSingleton.onUserInteraction()
         dialog.dismiss()
     }
@@ -157,6 +164,9 @@ fun downloadNormal(
     val request = DownloadManager.Request(url.toUri()).apply {
         setMimeType(mimeType)
         userAgent?.let { addRequestHeader("User-Agent", it) }
+        CookieManager.getInstance().getCookie(url)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { addRequestHeader("Cookie", it) }
         setDescription("Downloading file...")
         setTitle(filename)
         setNotificationVisibility(
@@ -225,24 +235,28 @@ private fun fetchBlob(
             }
 
             try {
-                let blob = null;
+                const blobMap =
+                    window.__${Constants.APP_SCHEME}_blobsByUrl;
+                let blob = blobMap ? blobMap.get(blobUrl) : null;
 
-                try {
-                    const response = await fetch(blobUrl);
+                // Prefer the captured Blob. Besides avoiding another read,
+                // this is required on sites whose CSP disallows fetch(blob:).
+                if (!blob) {
+                    try {
+                        const response = await fetch(blobUrl);
 
-                    if (!response.ok) {
-                        throw new Error(
-                            'Blob fetch returned HTTP ' + response.status
-                        );
-                    }
+                        if (!response.ok) {
+                            throw new Error(
+                                'Blob fetch returned HTTP ' + response.status
+                            );
+                        }
 
-                    blob = await response.blob();
-                } catch (e) {
-                    blob = window.__${Constants.APP_SCHEME}_lastBlob || null;
+                        blob = await response.blob();
+                    } catch (_) {}
                 }
 
                 if (!blob) {
-                    throw new Error('Blob fetch failed');
+                    throw new Error('Blob is no longer available');
                 }
 
                 if (!bridge.startDownload(
@@ -284,14 +298,20 @@ private fun fetchBlob(
                     );
                 }
 
-                // Your hook keeps a strong reference to the most recently
-                // created blob. Release it after the file has been written.
-                window.__${Constants.APP_SCHEME}_lastBlob = null;
+                if (blobMap) {
+                    blobMap.delete(blobUrl);
+                }
 
             } catch (e) {
                 try {
                     bridge.abortDownload(transferId);
                 } catch (_) {}
+
+                const blobMap =
+                    window.__${Constants.APP_SCHEME}_blobsByUrl;
+                if (blobMap) {
+                    blobMap.delete(blobUrl);
+                }
 
                 bridge.error(
                     'Blob download failed: ' +
@@ -302,6 +322,18 @@ private fun fetchBlob(
     """.trimIndent()
 
     webView.evaluateJavascript(js, null)
+}
+
+private fun releaseCapturedBlob(
+    webView: WebView,
+    blobUrl: String
+) {
+    val quotedBlobUrl = JSONObject.quote(blobUrl)
+    webView.evaluateJavascript(
+        "window.__${Constants.APP_SCHEME}_blobsByUrl && " +
+            "window.__${Constants.APP_SCHEME}_blobsByUrl.delete($quotedBlobUrl);",
+        null
+    )
 }
 
 private fun generateBlobFilename(mimeType: String?): String {

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handlePdfSourceRequest.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/handlers/handlePdfSourceRequest.kt
@@ -1,0 +1,120 @@
+package uk.nktnet.webviewkiosk.utils.webview.handlers
+
+import android.util.Log
+import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import androidx.core.net.toUri
+import uk.nktnet.webviewkiosk.config.Constants
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+fun handlePdfSourceRequest(
+    request: WebResourceRequest,
+    userAgent: String?,
+    allowLocalFiles: Boolean
+): WebResourceResponse? {
+    val requestUrl = request.url
+    val expectedHost = Constants.PDF_JS_ASSETS_DUMMY_URL.toUri().host
+
+    if (requestUrl.host != expectedHost || requestUrl.path != "/pdf_source") {
+        return null
+    }
+
+    val sourceUrl = requestUrl.getQueryParameter("wk_pdf_url")
+        ?: return errorResponse(400, "Missing PDF URL")
+    val sourceUri = sourceUrl.toUri()
+
+    return try {
+        when (sourceUri.scheme?.lowercase()) {
+            "file" -> {
+                if (!allowLocalFiles) {
+                    return errorResponse(403, "Local file access is disabled")
+                }
+
+                val path = sourceUri.path
+                    ?: return errorResponse(400, "Invalid file URL")
+                val file = File(path)
+
+                if (!file.isFile) {
+                    return errorResponse(404, "PDF not found")
+                }
+
+                WebResourceResponse(
+                    "application/pdf",
+                    null,
+                    FileInputStream(file)
+                )
+            }
+            "http", "https" -> remotePdfResponse(sourceUrl, userAgent)
+            else -> errorResponse(400, "Unsupported PDF URL")
+        }
+    } catch (e: Exception) {
+        Log.e(Constants.APP_SCHEME, "Failed to load PDF source: $sourceUrl", e)
+        errorResponse(502, "Failed to load PDF")
+    }
+}
+
+private fun remotePdfResponse(
+    sourceUrl: String,
+    userAgent: String?
+): WebResourceResponse {
+    val connection = URL(sourceUrl).openConnection() as HttpURLConnection
+    connection.instanceFollowRedirects = true
+    connection.connectTimeout = 15_000
+    connection.readTimeout = 30_000
+
+    userAgent?.takeIf { it.isNotBlank() }?.let {
+        connection.setRequestProperty("User-Agent", it)
+    }
+    CookieManager.getInstance().getCookie(sourceUrl)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { connection.setRequestProperty("Cookie", it) }
+
+    val statusCode = connection.responseCode
+    val responseMessage = connection.responseMessage
+        ?.takeIf { it.isNotBlank() }
+        ?: if (statusCode in 200..299) "OK" else "Error"
+    val input = if (statusCode in 200..299) {
+        connection.inputStream
+    } else {
+        connection.errorStream ?: ByteArrayInputStream(ByteArray(0))
+    }
+    return WebResourceResponse(
+        connection.contentType?.substringBefore(';') ?: "application/pdf",
+        null,
+        statusCode,
+        responseMessage,
+        emptyMap(),
+        DisconnectingInputStream(input, connection)
+    )
+}
+
+private fun errorResponse(statusCode: Int, message: String): WebResourceResponse {
+    return WebResourceResponse(
+        "text/plain",
+        "UTF-8",
+        statusCode,
+        message,
+        emptyMap(),
+        ByteArrayInputStream(message.toByteArray(Charsets.UTF_8))
+    )
+}
+
+private class DisconnectingInputStream(
+    input: InputStream,
+    private val connection: HttpURLConnection
+) : FilterInputStream(input) {
+    override fun close() {
+        try {
+            super.close()
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generatePdfRendererHtml.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/html/generatePdfRendererHtml.kt
@@ -1,8 +1,18 @@
 package uk.nktnet.webviewkiosk.utils.webview.html
 
+import android.net.Uri
+import org.json.JSONObject
 import uk.nktnet.webviewkiosk.config.Constants
 
-fun generatePdfRendererHtml(pdfBase64Data: String): String {
+fun generatePdfRendererHtml(pdfUrl: String): String {
+    val pdfSourceUrl = Uri.parse(Constants.PDF_JS_ASSETS_DUMMY_URL)
+        .buildUpon()
+        .appendPath("pdf_source")
+        .appendQueryParameter("wk_pdf_url", pdfUrl)
+        .build()
+        .toString()
+    val quotedPdfSourceUrl = JSONObject.quote(pdfSourceUrl)
+
     return """
         <!DOCTYPE html>
         <html>
@@ -28,35 +38,28 @@ fun generatePdfRendererHtml(pdfBase64Data: String): String {
                 import * as pdfjsLib from '${Constants.PDF_JS_ASSETS_DUMMY_URL}/pdfjs_local/pdf.mjs';
                 pdfjsLib.GlobalWorkerOptions.workerSrc = '${Constants.PDF_JS_ASSETS_DUMMY_URL}/pdfjs_local/pdf.worker.mjs';
 
-                try {
-                    const base64Data = "$pdfBase64Data";
-                    const binaryString = atob(base64Data);
-                    const len = binaryString.length;
-                    const bytes = new Uint8Array(len);
-                    for (let i = 0; i < len; i++) {
-                        bytes[i] = binaryString.charCodeAt(i);
-                    }
+                const pdfSourceUrl = $quotedPdfSourceUrl;
 
-                    pdfjsLib.getDocument({ data: bytes }).promise.then(pdf => {
-                        const container = document.getElementById('pdf-container');
-                        container.innerHTML = '';
-                        for (let i = 1; i <= pdf.numPages; i++) {
-                            pdf.getPage(i).then(page => {
-                                const viewport = page.getViewport({ scale: 1.5 });
-                                const canvas = document.createElement('canvas');
-                                const context = canvas.getContext('2d');
-                                canvas.height = viewport.height;
-                                canvas.width = viewport.width;
-                                container.appendChild(canvas);
-                                page.render({ canvasContext: context, viewport: viewport });
-                            });
-                        }
-                    }).catch(err => {
-                        console.error("PDF.js inner error: ", err);
-                    });
-                } catch (err) {
-                    console.error("Base64 decoding error: ", err);
-                }
+                pdfjsLib.getDocument({
+                    url: pdfSourceUrl,
+                    disableRange: true
+                }).promise.then(pdf => {
+                    const container = document.getElementById('pdf-container');
+                    container.innerHTML = '';
+                    for (let i = 1; i <= pdf.numPages; i++) {
+                        pdf.getPage(i).then(page => {
+                            const viewport = page.getViewport({ scale: 1.5 });
+                            const canvas = document.createElement('canvas');
+                            const context = canvas.getContext('2d');
+                            canvas.height = viewport.height;
+                            canvas.width = viewport.width;
+                            container.appendChild(canvas);
+                            page.render({ canvasContext: context, viewport: viewport });
+                        });
+                    }
+                }).catch(err => {
+                    console.error("PDF.js error: ", err);
+                });
             </script>
         </body>
         </html>

--- a/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
+++ b/app/src/main/java/uk/nktnet/webviewkiosk/utils/webview/interfaces/BlobInterface.kt
@@ -19,15 +19,6 @@ class BlobInterface(
     companion object {
         const val NAME = "WebviewKioskBlobInterface"
 
-        @JvmStatic
-        private var isActive = true
-
-        @Suppress("unused")
-        @JvmStatic
-        fun setIsActive(value: Boolean) {
-            isActive = value
-        }
-
         const val JS_BLOB_HOOK = """
             (function() {
                 if (window.__${Constants.APP_SCHEME}_blobHookInstalled) {
@@ -35,12 +26,19 @@ class BlobInterface(
                 }
 
                 window.__${Constants.APP_SCHEME}_blobHookInstalled = true;
+                window.__${Constants.APP_SCHEME}_blobsByUrl = new Map();
 
-                const orig = URL.createObjectURL;
+                const origCreateObjectURL = URL.createObjectURL;
 
                 URL.createObjectURL = function(blob) {
-                    window.__${Constants.APP_SCHEME}_lastBlob = blob;
-                    return orig.call(URL, blob);
+                    const url = origCreateObjectURL.call(URL, blob);
+                    // Keep the Blob available even if the page immediately
+                    // revokes its object URL. Some sites (including GitHub)
+                    // revoke download URLs before the native download prompt
+                    // has been confirmed. The entry is removed after the
+                    // download succeeds, fails, or is cancelled.
+                    window.__${Constants.APP_SCHEME}_blobsByUrl.set(url, blob);
+                    return url;
                 };
             })();
         """
@@ -52,8 +50,16 @@ class BlobInterface(
         val mimeType: String?
     )
 
+    @Volatile
+    private var isActive = true
+
     private val activeDownloads =
         ConcurrentHashMap<String, ActiveDownload>()
+
+    fun dispose() {
+        isActive = false
+        activeDownloads.keys.toList().forEach(::abortInternal)
+    }
 
     @JavascriptInterface
     fun error(message: String?) {
@@ -84,12 +90,7 @@ class BlobInterface(
 
         return try {
             // Clean up an accidentally reused transfer ID.
-            activeDownloads.remove(transferId)?.let {
-                try {
-                    it.output.close()
-                } catch (_: Exception) {
-                }
-            }
+            abortInternal(transferId)
 
             val downloads =
                 Environment.getExternalStoragePublicDirectory(
@@ -140,6 +141,9 @@ class BlobInterface(
             )
 
             synchronized(download) {
+                if (!isActive || activeDownloads[transferId] !== download) {
+                    return false
+                }
                 download.output.write(bytes)
             }
 
@@ -162,13 +166,22 @@ class BlobInterface(
         transferId: String
     ): Boolean {
         val download =
-            activeDownloads.remove(transferId)
+            activeDownloads[transferId]
                 ?: return false
 
         return try {
-            synchronized(download) {
-                download.output.flush()
-                download.output.close()
+            val completed = synchronized(download) {
+                if (!isActive || activeDownloads[transferId] !== download) {
+                    false
+                } else {
+                    download.output.flush()
+                    download.output.close()
+                    activeDownloads.remove(transferId, download)
+                }
+            }
+
+            if (!completed) {
+                return false
             }
 
             ToastManager.show(
@@ -182,17 +195,14 @@ class BlobInterface(
                 CustomNotificationManager
                     .sendBlobDownloadNotification(
                         context,
-                        download.file
+                        download.file,
+                        download.mimeType
                     )
             }
 
             true
         } catch (e: Exception) {
-            try {
-                download.output.close()
-            } catch (e: Exception) {
-                Log.e(javaClass.simpleName, "Failed to close download output", e)
-            }
+            abortInternal(transferId)
 
             ToastManager.show(
                 context,
@@ -215,23 +225,29 @@ class BlobInterface(
         transferId: String
     ) {
         val download =
-            activeDownloads.remove(transferId)
+            activeDownloads[transferId]
                 ?: return
 
-        try {
-            download.output.close()
-        } catch (e: Exception) {
-            Log.e(
-                javaClass.simpleName,
-                "Failed to close download output during abort",
-                e
-            )
-        }
+        synchronized(download) {
+            if (!activeDownloads.remove(transferId, download)) {
+                return
+            }
 
-        try {
-            download.file.delete()
-        } catch (e: Exception) {
-            Log.e(javaClass.simpleName, "Failed to delete file during abort", e)
+            try {
+                download.output.close()
+            } catch (e: Exception) {
+                Log.e(
+                    javaClass.simpleName,
+                    "Failed to close download output during abort",
+                    e
+                )
+            }
+
+            try {
+                download.file.delete()
+            } catch (e: Exception) {
+                Log.e(javaClass.simpleName, "Failed to delete file during abort", e)
+            }
         }
     }
 


### PR DESCRIPTION
Changes:

- fix: blob downloads on strict CSP sites
- fix: blob URL mapping
- fix: blob transfer cleanup
- fix: MIME types in download notifications
- fix: authenticated downloads with WebView cookies
- fix: large PDF memory usage
- fix: authenticated and local PDF loading
- fix: partial PDF.js downloads
- feat: pin PDF.js version
- fix: MQTT busy-looping
- fix: stale Activity references
- fix: UnifiedPush VAPID error logging
- fix: WebView recreation after renderer crashes
